### PR TITLE
Integrate anofox-regression 0.5.2: solver selection + HC standard errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ thiserror = "2.0.17"
 serde = { version = "1.0.228", features = ["derive"] }
 
 # Regression
-anofox-regression = "0.5.1"
+anofox-regression = "0.5.2"
 
 # Statistics
 anofox-statistics = "0.4.0"

--- a/python/polars_statistics/exprs/regression.py
+++ b/python/polars_statistics/exprs/regression.py
@@ -53,6 +53,7 @@ def ols(
     *x: Union[pl.Expr, str],
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Ordinary Least Squares regression as a Polars expression.
 
@@ -66,6 +67,8 @@ def ols(
         Feature variables (one or more).
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
 
     Returns
     -------
@@ -112,6 +115,7 @@ def ols(
         args=[
             y.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             *x_exprs,
         ],
         returns_scalar=True,
@@ -124,6 +128,7 @@ def ridge(
     lambda_: float = 1.0,
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Ridge regression (L2 regularization) as a Polars expression.
 
@@ -137,6 +142,8 @@ def ridge(
         Regularization strength.
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
 
     Returns
     -------
@@ -160,6 +167,7 @@ def ridge(
             y.cast(pl.Float64),
             pl.lit(lambda_, dtype=pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             *x_exprs,
         ],
         returns_scalar=True,
@@ -224,6 +232,7 @@ def wls(
     *x: Union[pl.Expr, str],
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Weighted Least Squares regression as a Polars expression.
 
@@ -237,6 +246,8 @@ def wls(
         Feature variables (one or more).
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
 
     Returns
     -------
@@ -262,6 +273,7 @@ def wls(
             y.cast(pl.Float64),
             weights.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             *x_exprs,
         ],
         returns_scalar=True,
@@ -1212,6 +1224,8 @@ def ols_summary(
     *x: Union[pl.Expr, str],
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
+    hc_type: str | None = None,
 ) -> pl.Expr:
     """OLS coefficient summary in tidy format (like R's broom::tidy).
 
@@ -1226,6 +1240,11 @@ def ols_summary(
         Feature variables (one or more).
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
+    hc_type : str or None, default None
+        Heteroskedasticity-consistent standard errors variant:
+        "hc0", "hc1", "hc2", or "hc3". If None, uses homoskedastic SEs.
 
     Returns
     -------
@@ -1236,6 +1255,11 @@ def ols_summary(
     --------
     >>> df.group_by("group").agg(
     ...     ps.ols_summary("y", "x1", "x2").alias("coef")
+    ... ).explode("coef").unnest("coef")
+    >>>
+    >>> # With robust standard errors
+    >>> df.group_by("group").agg(
+    ...     ps.ols_summary("y", "x1", "x2", hc_type="hc3").alias("coef")
     ... ).explode("coef").unnest("coef")
     """
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
@@ -1254,6 +1278,8 @@ def ols_summary(
         args=[
             y.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
+            pl.lit(hc_type, dtype=pl.String),
             *x_exprs,
         ],
         returns_scalar=True,
@@ -1266,9 +1292,9 @@ def ridge_summary(
     lambda_: float = 1.0,
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Ridge regression coefficient summary in tidy format."""
-    add_intercept = _resolve_intercept(add_intercept, with_intercept)
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
     if isinstance(y, str):
         y = pl.col(y)
@@ -1286,6 +1312,7 @@ def ridge_summary(
             y.cast(pl.Float64),
             pl.lit(lambda_, dtype=pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             *x_exprs,
         ],
         returns_scalar=True,
@@ -1350,9 +1377,9 @@ def wls_summary(
     *x: Union[pl.Expr, str],
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Weighted Least Squares coefficient summary in tidy format."""
-    add_intercept = _resolve_intercept(add_intercept, with_intercept)
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
     if isinstance(y, str):
         y = pl.col(y)
@@ -1372,6 +1399,7 @@ def wls_summary(
             y.cast(pl.Float64),
             weights.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             *x_exprs,
         ],
         returns_scalar=True,
@@ -1691,6 +1719,7 @@ def ols_predict(
     y: Union[pl.Expr, str],
     *x: Union[pl.Expr, str],
     add_intercept: bool = True,
+    solve_method: str | None = None,
     interval: str | None = None,
     level: float = 0.95,
     null_policy: str = "drop",
@@ -1708,6 +1737,8 @@ def ols_predict(
         Feature variables (one or more).
     add_intercept : bool, default True
         Whether to include an intercept term in the model.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
     interval : str or None, default None
         Type of interval to compute:
         - None: No intervals (lower/upper will be NaN)
@@ -1778,6 +1809,7 @@ def ols_predict(
         args=[
             y.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             interval_lit,
             pl.lit(level, dtype=pl.Float64),
             pl.lit(null_policy, dtype=pl.String),
@@ -1793,6 +1825,7 @@ def ridge_predict(
     *x: Union[pl.Expr, str],
     lambda_: float = 1.0,
     add_intercept: bool = True,
+    solve_method: str | None = None,
     interval: str | None = None,
     level: float = 0.95,
     null_policy: str = "drop",
@@ -1810,6 +1843,8 @@ def ridge_predict(
         Regularization strength.
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
     interval : str or None, default None
         "confidence" or "prediction" intervals.
     level : float, default 0.95
@@ -1842,6 +1877,7 @@ def ridge_predict(
         args=[
             y.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             interval_lit,
             pl.lit(level, dtype=pl.Float64),
             pl.lit(null_policy, dtype=pl.String),
@@ -1977,6 +2013,7 @@ def wls_predict(
     weights: Union[pl.Expr, str],
     *x: Union[pl.Expr, str],
     add_intercept: bool = True,
+    solve_method: str | None = None,
     interval: str | None = None,
     level: float = 0.95,
     null_policy: str = "drop",
@@ -1994,6 +2031,8 @@ def wls_predict(
         Feature variables.
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
     interval : str or None, default None
         "confidence" or "prediction" intervals.
     level : float, default 0.95
@@ -2028,6 +2067,7 @@ def wls_predict(
         args=[
             y.cast(pl.Float64),
             pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(solve_method, dtype=pl.String),
             interval_lit,
             pl.lit(level, dtype=pl.Float64),
             pl.lit(null_policy, dtype=pl.String),
@@ -2690,6 +2730,7 @@ def ols_formula(
     formula: str,
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """OLS regression using R-style formula syntax.
 
@@ -2708,6 +2749,8 @@ def ols_formula(
         - Transform: "y ~ I(x^2)"
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
 
     Returns
     -------
@@ -2738,7 +2781,7 @@ def ols_formula(
     """
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
     response, x_exprs, _ = _parse_formula(formula)
-    return ols(response, *x_exprs, add_intercept=add_intercept)
+    return ols(response, *x_exprs, add_intercept=add_intercept, solve_method=solve_method)
 
 
 def ridge_formula(
@@ -2746,6 +2789,7 @@ def ridge_formula(
     lambda_: float = 1.0,
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Ridge regression using R-style formula syntax.
 
@@ -2757,6 +2801,8 @@ def ridge_formula(
         Regularization strength.
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
 
     Returns
     -------
@@ -2765,7 +2811,7 @@ def ridge_formula(
     """
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
     response, x_exprs, _ = _parse_formula(formula)
-    return ridge(response, *x_exprs, lambda_=lambda_, add_intercept=add_intercept)
+    return ridge(response, *x_exprs, lambda_=lambda_, add_intercept=add_intercept, solve_method=solve_method)
 
 
 def elastic_net_formula(
@@ -2836,6 +2882,7 @@ def wls_formula(
     weights: Union[pl.Expr, str],
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Weighted Least Squares regression using R-style formula syntax.
 
@@ -2847,6 +2894,8 @@ def wls_formula(
         Observation weights column.
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
 
     Returns
     -------
@@ -2855,7 +2904,7 @@ def wls_formula(
     """
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
     response, x_exprs, _ = _parse_formula(formula)
-    return wls(response, weights, *x_exprs, add_intercept=add_intercept)
+    return wls(response, weights, *x_exprs, add_intercept=add_intercept, solve_method=solve_method)
 
 
 def rls_formula(
@@ -3132,6 +3181,8 @@ def ols_formula_summary(
     formula: str,
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
+    hc_type: str | None = None,
 ) -> pl.Expr:
     """OLS coefficient summary using R-style formula syntax.
 
@@ -3141,6 +3192,11 @@ def ols_formula_summary(
         R-style formula (see ols_formula for syntax).
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
+    hc_type : str or None, default None
+        Heteroskedasticity-consistent standard errors variant:
+        "hc0", "hc1", "hc2", or "hc3". If None, uses homoskedastic SEs.
 
     Returns
     -------
@@ -3149,7 +3205,7 @@ def ols_formula_summary(
     """
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
     response, x_exprs, _ = _parse_formula(formula)
-    return ols_summary(response, *x_exprs, add_intercept=add_intercept)
+    return ols_summary(response, *x_exprs, add_intercept=add_intercept, solve_method=solve_method, hc_type=hc_type)
 
 
 def ridge_formula_summary(
@@ -3157,12 +3213,12 @@ def ridge_formula_summary(
     lambda_: float = 1.0,
     add_intercept: bool | None = None,
     with_intercept: bool | None = None,
+    solve_method: str | None = None,
 ) -> pl.Expr:
     """Ridge coefficient summary using R-style formula syntax."""
     add_intercept = _resolve_intercept(add_intercept, with_intercept)
-    add_intercept = _resolve_intercept(add_intercept, with_intercept)
     response, x_exprs, _ = _parse_formula(formula)
-    return ridge_summary(response, *x_exprs, lambda_=lambda_, add_intercept=add_intercept)
+    return ridge_summary(response, *x_exprs, lambda_=lambda_, add_intercept=add_intercept, solve_method=solve_method)
 
 
 def elastic_net_formula_summary(
@@ -3242,6 +3298,7 @@ def alm_formula_summary(
 def ols_formula_predict(
     formula: str,
     add_intercept: bool = True,
+    solve_method: str | None = None,
     interval: str | None = None,
     level: float = 0.95,
     null_policy: str = "drop",
@@ -3255,6 +3312,8 @@ def ols_formula_predict(
         R-style formula (see ols_formula for syntax).
     add_intercept : bool, default True
         Whether to include an intercept term.
+    solve_method : str or None, default None
+        Solver for the linear system: "qr" (default), "svd", or "cholesky".
     interval : str or None, default None
         "confidence" or "prediction" intervals.
     level : float, default 0.95
@@ -3282,6 +3341,7 @@ def ols_formula_predict(
         response,
         *x_exprs,
         add_intercept=add_intercept,
+        solve_method=solve_method,
         interval=interval,
         level=level,
         null_policy=null_policy,
@@ -3293,6 +3353,7 @@ def ridge_formula_predict(
     formula: str,
     lambda_: float = 1.0,
     add_intercept: bool = True,
+    solve_method: str | None = None,
     interval: str | None = None,
     level: float = 0.95,
     null_policy: str = "drop",
@@ -3305,6 +3366,7 @@ def ridge_formula_predict(
         *x_exprs,
         lambda_=lambda_,
         add_intercept=add_intercept,
+        solve_method=solve_method,
         interval=interval,
         level=level,
         null_policy=null_policy,

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -18,10 +18,29 @@ use anofox_regression::solvers::{
     PoissonRegressor, QuantileRegressor, Regressor, RidgeRegressor, RlsRegressor, TweedieRegressor,
     WlsRegressor,
 };
-use anofox_regression::IntervalType;
+use anofox_regression::{HcType, IntervalType, SolverType};
 
 /// Result type for build_xy_with_null_policy: (X_fit, y, valid_mask, X_pred)
 type XyNullPolicyResult = (Mat<f64>, Col<f64>, Vec<bool>, Mat<f64>);
+
+/// Parse a solver type string into a SolverType enum.
+fn parse_solver_type(s: Option<&str>) -> Option<SolverType> {
+    s.map(|v| match v {
+        "svd" => SolverType::Svd,
+        "cholesky" => SolverType::Cholesky,
+        _ => SolverType::Qr,
+    })
+}
+
+/// Parse an HC type string into an HcType enum.
+fn parse_hc_type(s: Option<&str>) -> Option<HcType> {
+    s.map(|v| match v {
+        "hc0" => HcType::HC0,
+        "hc2" => HcType::HC2,
+        "hc3" => HcType::HC3,
+        _ => HcType::HC1,
+    })
+}
 
 // ============================================================================
 // Output Type Definitions
@@ -380,19 +399,22 @@ fn summary_nan_output() -> PolarsResult<Series> {
 // ============================================================================
 
 /// OLS regression expression.
-/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2..] = x columns
+/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2] = solve_method (string or null), inputs[3..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
 fn pl_ols(inputs: &[Series]) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
+    let solve_method = parse_solver_type(inputs[2].str()?.get(0));
 
-    let (x, y) = match build_xy_data(inputs, 0, 2) {
+    let (x, y) = match build_xy_data(inputs, 0, 3) {
         Ok(data) => data,
         Err(_) => return linear_nan_output(),
     };
 
-    let model = OlsRegressor::builder()
-        .with_intercept(with_intercept)
-        .build();
+    let mut builder = OlsRegressor::builder().with_intercept(with_intercept);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x, &y) {
         Ok(fitted) => {
@@ -416,21 +438,25 @@ fn pl_ols(inputs: &[Series]) -> PolarsResult<Series> {
 }
 
 /// Ridge regression expression.
-/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3..] = x columns
+/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
 fn pl_ridge(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(1.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
+    let solve_method = parse_solver_type(inputs[3].str()?.get(0));
 
-    let (x, y) = match build_xy_data(inputs, 0, 3) {
+    let (x, y) = match build_xy_data(inputs, 0, 4) {
         Ok(data) => data,
         Err(_) => return linear_nan_output(),
     };
 
-    let model = RidgeRegressor::builder()
+    let mut builder = RidgeRegressor::builder()
         .lambda(lambda)
-        .with_intercept(with_intercept)
-        .build();
+        .with_intercept(with_intercept);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x, &y) {
         Ok(fitted) => {
@@ -494,13 +520,14 @@ fn pl_elastic_net(inputs: &[Series]) -> PolarsResult<Series> {
 }
 
 /// WLS regression expression.
-/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3..] = x columns
+/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
 fn pl_wls(inputs: &[Series]) -> PolarsResult<Series> {
     let weights_series = inputs[1].f64()?;
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
+    let solve_method = parse_solver_type(inputs[3].str()?.get(0));
 
-    let (x, y) = match build_xy_data(inputs, 0, 3) {
+    let (x, y) = match build_xy_data(inputs, 0, 4) {
         Ok(data) => data,
         Err(_) => return linear_nan_output(),
     };
@@ -508,10 +535,13 @@ fn pl_wls(inputs: &[Series]) -> PolarsResult<Series> {
     let weights_vec: Vec<f64> = weights_series.into_no_null_iter().collect();
     let weights = Col::from_fn(weights_vec.len(), |i| weights_vec[i]);
 
-    let model = WlsRegressor::builder()
+    let mut builder = WlsRegressor::builder()
         .with_intercept(with_intercept)
-        .weights(weights)
-        .build();
+        .weights(weights);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x, &y) {
         Ok(fitted) => {
@@ -1214,24 +1244,30 @@ fn build_term_names(n_features: usize, with_intercept: bool) -> Vec<String> {
 }
 
 /// OLS summary expression - returns tidy coefficient table
-/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2..] = x columns
+/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2] = solve_method (string or null),
+/// inputs[3] = hc_type (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
 fn pl_ols_summary(inputs: &[Series]) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
-    let n_features = inputs.len() - 2;
+    let solve_method = parse_solver_type(inputs[2].str()?.get(0));
+    let hc_type = parse_hc_type(inputs[3].str()?.get(0));
+    let n_features = inputs.len() - 4;
 
-    let (x, y) = match build_xy_data(inputs, 0, 2) {
+    let (x, y) = match build_xy_data(inputs, 0, 4) {
         Ok(data) => data,
         Err(_) => return summary_nan_output(),
     };
 
-    let model = OlsRegressor::builder()
+    let mut builder = OlsRegressor::builder()
         .with_intercept(with_intercept)
-        .build();
+        .compute_inference(true);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x, &y) {
         Ok(fitted) => {
-            let result = fitted.result();
             let terms = build_term_names(n_features, with_intercept);
 
             // Build coefficient vectors including intercept
@@ -1239,6 +1275,36 @@ fn pl_ols_summary(inputs: &[Series]) -> PolarsResult<Series> {
             let mut std_errors = Vec::new();
             let mut statistics = Vec::new();
             let mut p_values = Vec::new();
+
+            // If HC type is specified, use robust inference
+            if let Some(hc) = hc_type {
+                if let Ok(hc_inf) = fitted.hc_inference(&x, hc) {
+                    if with_intercept {
+                        estimates.push(fitted.intercept().unwrap_or(f64::NAN));
+                        if let Some(ref int_hc) = hc_inf.intercept {
+                            std_errors.push(int_hc.std_error);
+                            statistics.push(int_hc.t_statistic);
+                            p_values.push(int_hc.p_value);
+                        } else {
+                            std_errors.push(f64::NAN);
+                            statistics.push(f64::NAN);
+                            p_values.push(f64::NAN);
+                        }
+                    }
+
+                    let coefs = col_to_vec(fitted.coefficients());
+                    estimates.extend(coefs);
+                    std_errors.extend(col_to_vec(&hc_inf.std_errors));
+                    statistics.extend(col_to_vec(&hc_inf.t_statistics));
+                    p_values.extend(col_to_vec(&hc_inf.p_values));
+
+                    return summary_output(terms, estimates, std_errors, statistics, p_values);
+                }
+                // Fall through to homoskedastic if HC computation fails
+            }
+
+            // Default homoskedastic path
+            let result = fitted.result();
 
             if with_intercept {
                 estimates.push(fitted.intercept().unwrap_or(f64::NAN));
@@ -1276,22 +1342,26 @@ fn pl_ols_summary(inputs: &[Series]) -> PolarsResult<Series> {
 }
 
 /// Ridge summary expression
-/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3..] = x columns
+/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
 fn pl_ridge_summary(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(1.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
-    let n_features = inputs.len() - 3;
+    let solve_method = parse_solver_type(inputs[3].str()?.get(0));
+    let n_features = inputs.len() - 4;
 
-    let (x, y) = match build_xy_data(inputs, 0, 3) {
+    let (x, y) = match build_xy_data(inputs, 0, 4) {
         Ok(data) => data,
         Err(_) => return summary_nan_output(),
     };
 
-    let model = RidgeRegressor::builder()
+    let mut builder = RidgeRegressor::builder()
         .lambda(lambda)
-        .with_intercept(with_intercept)
-        .build();
+        .with_intercept(with_intercept);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x, &y) {
         Ok(fitted) => {
@@ -1402,14 +1472,15 @@ fn pl_elastic_net_summary(inputs: &[Series]) -> PolarsResult<Series> {
 }
 
 /// WLS summary expression
-/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3..] = x columns
+/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
 fn pl_wls_summary(inputs: &[Series]) -> PolarsResult<Series> {
     let weights_series = inputs[1].f64()?;
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
-    let n_features = inputs.len() - 3;
+    let solve_method = parse_solver_type(inputs[3].str()?.get(0));
+    let n_features = inputs.len() - 4;
 
-    let (x, y) = match build_xy_data(inputs, 0, 3) {
+    let (x, y) = match build_xy_data(inputs, 0, 4) {
         Ok(data) => data,
         Err(_) => return summary_nan_output(),
     };
@@ -1417,10 +1488,13 @@ fn pl_wls_summary(inputs: &[Series]) -> PolarsResult<Series> {
     let weights_vec: Vec<f64> = weights_series.into_no_null_iter().collect();
     let weights = Col::from_fn(weights_vec.len(), |i| weights_vec[i]);
 
-    let model = WlsRegressor::builder()
+    let mut builder = WlsRegressor::builder()
         .with_intercept(with_intercept)
-        .weights(weights)
-        .build();
+        .weights(weights);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x, &y) {
         Ok(fitted) => {
@@ -2173,29 +2247,32 @@ fn build_xy_with_null_policy(
 }
 
 /// OLS prediction expression - returns predictions with optional intervals.
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval (string or null),
-/// inputs[3] = level, inputs[4] = null_policy, inputs[5..] = x columns
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
+/// inputs[3] = interval (string or null), inputs[4] = level, inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
 fn pl_ols_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
-    let interval = inputs[2].str()?.get(0); // None, "confidence", or "prediction"
-    let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
-    let null_policy = inputs[4].str()?.get(0).unwrap_or("drop");
+    let solve_method = parse_solver_type(inputs[2].str()?.get(0));
+    let interval = inputs[3].str()?.get(0); // None, "confidence", or "prediction"
+    let level = inputs[4].f64()?.get(0).unwrap_or(0.95);
+    let null_policy = inputs[5].str()?.get(0).unwrap_or("drop");
     let prefix = &kwargs.prefix;
 
     // Get number of rows from the first series
     let n_rows = inputs[0].len();
 
     // Build data with null handling
-    let (x_fit, y, valid_mask, x_pred) = match build_xy_with_null_policy(inputs, 0, 5, null_policy)
+    let (x_fit, y, valid_mask, x_pred) = match build_xy_with_null_policy(inputs, 0, 6, null_policy)
     {
         Ok(data) => data,
         Err(_) => return prediction_nan_output_with_prefix(n_rows, prefix),
     };
 
-    let model = OlsRegressor::builder()
-        .with_intercept(with_intercept)
-        .build();
+    let mut builder = OlsRegressor::builder().with_intercept(with_intercept);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x_fit, &y) {
         Ok(fitted) => {
@@ -2251,29 +2328,33 @@ fn pl_ols_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
 }
 
 /// Ridge prediction expression
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
-/// inputs[4] = null_policy, inputs[5] = lambda, inputs[6..] = x columns
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
+/// inputs[3] = interval, inputs[4] = level, inputs[5] = null_policy, inputs[6] = lambda, inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
 fn pl_ridge_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
-    let interval = inputs[2].str()?.get(0);
-    let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
-    let null_policy = inputs[4].str()?.get(0).unwrap_or("drop");
-    let lambda = inputs[5].f64()?.get(0).unwrap_or(1.0);
+    let solve_method = parse_solver_type(inputs[2].str()?.get(0));
+    let interval = inputs[3].str()?.get(0);
+    let level = inputs[4].f64()?.get(0).unwrap_or(0.95);
+    let null_policy = inputs[5].str()?.get(0).unwrap_or("drop");
+    let lambda = inputs[6].f64()?.get(0).unwrap_or(1.0);
     let prefix = &kwargs.prefix;
 
     let n_rows = inputs[0].len();
 
-    let (x_fit, y, valid_mask, x_pred) = match build_xy_with_null_policy(inputs, 0, 6, null_policy)
+    let (x_fit, y, valid_mask, x_pred) = match build_xy_with_null_policy(inputs, 0, 7, null_policy)
     {
         Ok(data) => data,
         Err(_) => return prediction_nan_output_with_prefix(n_rows, prefix),
     };
 
-    let model = RidgeRegressor::builder()
+    let mut builder = RidgeRegressor::builder()
         .lambda(lambda)
-        .with_intercept(with_intercept)
-        .build();
+        .with_intercept(with_intercept);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x_fit, &y) {
         Ok(fitted) => {
@@ -2402,24 +2483,25 @@ fn pl_elastic_net_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsRes
     }
 }
 
-/// WLS prediction expression (weights column is inputs[6])
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
-/// inputs[4] = null_policy, inputs[5] = weights, inputs[6..] = x columns
+/// WLS prediction expression (weights column is inputs[7])
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
+/// inputs[3] = interval, inputs[4] = level, inputs[5] = null_policy, inputs[6] = weights, inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
 fn pl_wls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
-    let interval = inputs[2].str()?.get(0);
-    let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
-    let null_policy = inputs[4].str()?.get(0).unwrap_or("drop");
+    let solve_method = parse_solver_type(inputs[2].str()?.get(0));
+    let interval = inputs[3].str()?.get(0);
+    let level = inputs[4].f64()?.get(0).unwrap_or(0.95);
+    let null_policy = inputs[5].str()?.get(0).unwrap_or("drop");
     let prefix = &kwargs.prefix;
 
     let n_rows = inputs[0].len();
 
     // Build weights
-    let weights_series = inputs[5].f64()?;
+    let weights_series = inputs[6].f64()?;
     let weights = Col::from_fn(n_rows, |i| weights_series.get(i).unwrap_or(1.0));
 
-    let (x_fit, y, valid_mask, x_pred) = match build_xy_with_null_policy(inputs, 0, 6, null_policy)
+    let (x_fit, y, valid_mask, x_pred) = match build_xy_with_null_policy(inputs, 0, 7, null_policy)
     {
         Ok(data) => data,
         Err(_) => return prediction_nan_output_with_prefix(n_rows, prefix),
@@ -2433,10 +2515,13 @@ fn pl_wls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
         .collect();
     let weights_fit = Col::from_fn(valid_indices.len(), |i| weights[valid_indices[i]]);
 
-    let model = WlsRegressor::builder()
+    let mut builder = WlsRegressor::builder()
         .with_intercept(with_intercept)
-        .weights(weights_fit)
-        .build();
+        .weights(weights_fit);
+    if let Some(solver) = solve_method {
+        builder = builder.solve_method(solver);
+    }
+    let model = builder.build();
 
     match model.fit(&x_fit, &y) {
         Ok(fitted) => {

--- a/src/pymodels/py_ols.rs
+++ b/src/pymodels/py_ols.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 
 use anofox_regression::prelude::*;
 use anofox_regression::solvers::{FittedOls, OlsRegressor, Regressor};
+use anofox_regression::{HcType, SolverType};
 
 use crate::utils::{IntoNumpy, ToFaer};
 
@@ -42,6 +43,7 @@ pub struct PyOLS {
     with_intercept: bool,
     compute_inference: bool,
     confidence_level: f64,
+    solve_method: Option<String>,
     fitted: Option<FittedOls>,
 }
 
@@ -49,12 +51,18 @@ pub struct PyOLS {
 impl PyOLS {
     /// Create a new OLS model.
     #[new]
-    #[pyo3(signature = (with_intercept=true, compute_inference=true, confidence_level=0.95))]
-    fn new(with_intercept: bool, compute_inference: bool, confidence_level: f64) -> Self {
+    #[pyo3(signature = (with_intercept=true, compute_inference=true, confidence_level=0.95, solve_method=None))]
+    fn new(
+        with_intercept: bool,
+        compute_inference: bool,
+        confidence_level: f64,
+        solve_method: Option<String>,
+    ) -> Self {
         Self {
             with_intercept,
             compute_inference,
             confidence_level,
+            solve_method,
             fitted: None,
         }
     }
@@ -80,11 +88,19 @@ impl PyOLS {
         let x_mat = x.to_faer();
         let y_col = y.to_faer();
 
-        let model = OlsRegressor::builder()
+        let mut builder = OlsRegressor::builder()
             .with_intercept(slf.with_intercept)
             .compute_inference(slf.compute_inference)
-            .confidence_level(slf.confidence_level)
-            .build();
+            .confidence_level(slf.confidence_level);
+        if let Some(ref solver_str) = slf.solve_method {
+            let solver = match solver_str.as_str() {
+                "svd" => SolverType::Svd,
+                "cholesky" => SolverType::Cholesky,
+                _ => SolverType::Qr,
+            };
+            builder = builder.solve_method(solver);
+        }
+        let model = builder.build();
 
         let fitted = model
             .fit(&x_mat, &y_col)
@@ -334,6 +350,65 @@ impl PyOLS {
             .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Model not fitted"))?;
 
         Ok(fitted.result().n_parameters)
+    }
+
+    /// Compute HC (heteroskedasticity-consistent) standard errors.
+    ///
+    /// Parameters
+    /// ----------
+    /// x : array-like of shape (n_samples, n_features)
+    ///     The feature matrix used to fit the model.
+    /// hc_type : str, default "hc1"
+    ///     HC variant: "hc0", "hc1", "hc2", or "hc3".
+    ///
+    /// Returns
+    /// -------
+    /// dict
+    ///     Dictionary with keys: std_errors, t_statistics, p_values,
+    ///     conf_interval_lower, conf_interval_upper, and optionally
+    ///     intercept_std_error, intercept_t_statistic, intercept_p_value.
+    #[pyo3(signature = (x, hc_type="hc1"))]
+    fn hc_inference<'py>(
+        &self,
+        py: Python<'py>,
+        x: PyReadonlyArray2<'py, f64>,
+        hc_type: &str,
+    ) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
+        let fitted = self
+            .fitted
+            .as_ref()
+            .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Model not fitted"))?;
+
+        let hc = match hc_type {
+            "hc0" => HcType::HC0,
+            "hc2" => HcType::HC2,
+            "hc3" => HcType::HC3,
+            _ => HcType::HC1,
+        };
+
+        let x_mat = x.to_faer();
+        let result = fitted
+            .hc_inference(&x_mat, hc)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("std_errors", result.std_errors.into_numpy(py))?;
+        dict.set_item("t_statistics", result.t_statistics.into_numpy(py))?;
+        dict.set_item("p_values", result.p_values.into_numpy(py))?;
+        dict.set_item(
+            "conf_interval_lower",
+            result.conf_interval_lower.into_numpy(py),
+        )?;
+        dict.set_item(
+            "conf_interval_upper",
+            result.conf_interval_upper.into_numpy(py),
+        )?;
+        if let Some(ref int_inf) = result.intercept {
+            dict.set_item("intercept_std_error", int_inf.std_error)?;
+            dict.set_item("intercept_t_statistic", int_inf.t_statistic)?;
+            dict.set_item("intercept_p_value", int_inf.p_value)?;
+        }
+        Ok(dict)
     }
 
     /// Get a formatted summary of the regression results.


### PR DESCRIPTION
## Summary
- Bump `anofox-regression` dependency from 0.5.1 to 0.5.2
- Add `solve_method` parameter ("qr", "svd", "cholesky") to OLS, Ridge, and WLS model-fitting, summary, and prediction expressions (including all formula variants)
- Add `hc_type` parameter ("hc0"–"hc3") for heteroskedasticity-consistent standard errors in OLS summary expressions
- Add `hc_inference()` method and `solve_method` parameter to PyO3 `OLS` class

## Test plan
- [x] All 366 existing tests pass (`pytest tests/`)
- [x] Solver selection produces consistent results across QR/SVD/Cholesky
- [x] HC standard errors return different (robust) SEs compared to homoskedastic default
- [x] PyO3 OLS model `solve_method` and `hc_inference()` work correctly
- [x] Backward compatible: all new parameters default to `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)