### PR TITLE
Add MkDocs Material documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install mkdocs-material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ Thumbs.db
 # Maturin
 *.whl
 
+# MkDocs
+site/
+
 # Local development
 .env
 .envrc

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,118 @@
+# Getting Started
+
+## Installation
+
+```bash
+pip install polars-statistics
+```
+
+Requires Python 3.9+.
+
+## Statistical Tests
+
+All test functions work as Polars expressions, integrating with `group_by` and `over`:
+
+```python
+import polars as pl
+import polars_statistics as ps
+
+df = pl.DataFrame({
+    "treatment": [23.1, 25.3, 22.8, 24.5, 26.1],
+    "control": [20.2, 21.5, 19.8, 22.1, 20.9],
+})
+
+# Two-sample t-test
+result = df.select(
+    ps.ttest_ind("treatment", "control", alternative="two-sided")
+        .alias("test")
+)
+
+# Extract results from the returned struct
+result.with_columns(
+    pl.col("test").struct.field("statistic"),
+    pl.col("test").struct.field("p_value"),
+)
+```
+
+All tests return a struct with `statistic` and `p_value` fields. See the [Statistical Tests](api/tests/parametric.md) section for the full list of available tests.
+
+## Regression Models
+
+### Expression API
+
+Regression functions also work as Polars expressions:
+
+```python
+import polars as pl
+import polars_statistics as ps
+
+df = pl.DataFrame({
+    "group": ["A"] * 50 + ["B"] * 50,
+    "y": [...],
+    "x1": [...],
+    "x2": [...],
+})
+
+# OLS regression per group
+result = df.group_by("group").agg(
+    ps.ols("y", "x1", "x2").alias("model")
+)
+
+# Extract R-squared per group
+result.with_columns(
+    pl.col("model").struct.field("r_squared"),
+)
+```
+
+### Formula Syntax
+
+R-style formulas with polynomial and interaction effects:
+
+```python
+# Main effects + interaction
+ps.ols_formula("y ~ x1 * x2")  # Expands to: x1 + x2 + x1:x2
+
+# Polynomial regression
+ps.ols_formula("y ~ poly(x, 2)")
+```
+
+### Predictions with Intervals
+
+```python
+df.with_columns(
+    ps.ols_predict("y", "x1", "x2", interval="prediction", level=0.95)
+        .over("group").alias("pred")
+).unnest("pred")  # Columns: prediction, lower, upper
+```
+
+### Tidy Coefficient Summary
+
+```python
+df.group_by("group").agg(
+    ps.ols_summary("y", "x1", "x2").alias("coef")
+).explode("coef").unnest("coef")
+# Columns: term, estimate, std_error, statistic, p_value
+```
+
+## Model Classes
+
+For direct model access outside Polars expressions:
+
+```python
+from polars_statistics import OLS, Ridge, Logistic, ALM
+
+# Fit a model
+model = OLS(compute_inference=True).fit(X, y)
+print(model.coefficients, model.r_squared, model.p_values)
+
+# ALM with various distributions
+alm = ALM.laplace().fit(X, y)  # Robust to outliers
+```
+
+See the [Model Classes](api/classes/linear.md) section for all available classes.
+
+## Next Steps
+
+- [API Conventions](api/conventions.md) — Common patterns across all functions
+- [Output Structures](api/outputs.md) — Return type definitions for all functions
+- [Regression Diagnostics](api/regression/diagnostics.md) — Multicollinearity and separation checks

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,62 @@
+# polars-statistics
+
+High-performance statistical testing and regression for [Polars](https://pola.rs/) DataFrames, powered by Rust.
+
+---
+
+## Features
+
+- **Native Polars Expressions** — Full support for `group_by`, `over`, and lazy evaluation
+- **Statistical Tests** — Parametric, non-parametric, distributional, correlation, categorical, and TOST equivalence tests
+- **Regression Models** — OLS, Ridge, Elastic Net, WLS, Quantile, Isotonic, GLMs, ALM (24+ distributions)
+- **Formula Syntax** — R-style formulas with polynomial and interaction effects
+- **Diagnostics** — Condition number, quasi-separation detection, count sparsity checks
+- **High Performance** — Rust-powered with zero-copy data transfer and automatic parallelization
+
+## Installation
+
+```bash
+pip install polars-statistics
+```
+
+## Quick Example
+
+```python
+import polars as pl
+import polars_statistics as ps
+
+df = pl.DataFrame({
+    "group": ["A"] * 50 + ["B"] * 50,
+    "y": [...],
+    "x1": [...],
+    "x2": [...],
+})
+
+# OLS regression per group
+result = df.group_by("group").agg(
+    ps.ols("y", "x1", "x2").alias("model")
+)
+
+# Extract results
+result.with_columns(
+    pl.col("model").struct.field("r_squared"),
+    pl.col("model").struct.field("coefficients"),
+)
+```
+
+## What's in the Docs
+
+| Section | Description |
+|---------|-------------|
+| [Getting Started](getting-started.md) | Installation and first examples |
+| [API Conventions](api/conventions.md) | Common patterns across all functions |
+| [Statistical Tests](api/tests/parametric.md) | 30+ hypothesis tests |
+| [Regression](api/regression/linear.md) | Linear, GLM, ALM, dynamic models |
+| [Model Classes](api/classes/linear.md) | Direct Python class access |
+| [Output Structures](api/outputs.md) | Return type definitions |
+
+## Links
+
+- [GitHub Repository](https://github.com/DataZooDE/polars-statistics)
+- [PyPI Package](https://pypi.org/project/polars-statistics/)
+- [Polars Documentation](https://docs.pola.rs/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: polars-statistics
+site_url: https://datazoode.github.io/polars-statistics/
+site_description: High-performance statistical testing and regression for Polars DataFrames, powered by Rust.
+repo_url: https://github.com/DataZooDE/polars-statistics
+repo_name: DataZooDE/polars-statistics
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - API Conventions: api/conventions.md
+  - Statistical Tests:
+      - Parametric Tests: api/tests/parametric.md
+      - Non-Parametric Tests: api/tests/nonparametric.md
+      - Distributional Tests: api/tests/distributional.md
+      - Correlation Tests: api/tests/correlation.md
+      - Forecast Comparison: api/tests/forecast.md
+      - Categorical Tests: api/tests/categorical.md
+      - TOST Equivalence: api/tests/tost.md
+  - Regression:
+      - Linear Models: api/regression/linear.md
+      - GLM: api/regression/glm.md
+      - ALM: api/regression/alm.md
+      - Formula Syntax: api/regression/formula.md
+      - Summary & Prediction: api/regression/summary-predict.md
+      - Diagnostics: api/regression/diagnostics.md
+      - Dynamic Models: api/regression/dynamic.md
+      - Demand Classification (AID): api/regression/aid.md
+  - Model Classes:
+      - Linear: api/classes/linear.md
+      - GLM: api/classes/glm.md
+      - ALM: api/classes/alm.md
+      - AID: api/classes/aid.md
+      - Test Classes: api/classes/tests.md
+      - Dynamic: api/classes/dynamic.md
+      - Bootstrap: api/classes/bootstrap.md
+  - Reference:
+      - Output Structures: api/outputs.md
+      - API Overview: api/README.md


### PR DESCRIPTION
## Summary
- Add MkDocs Material configuration with dark mode, search, code copy, and structured navigation
- Create landing page (`docs/index.md`) and getting started guide (`docs/getting-started.md`)
- Add GitHub Actions workflow to auto-deploy to GitHub Pages on push to main
- All 25 existing `docs/api/` markdown files are mapped into the nav structure — no existing files modified

## Test plan
- [ ] Install locally: `pip install mkdocs-material && mkdocs serve`
- [ ] Verify site renders at localhost:8000 with all sections
- [ ] Merge → GitHub Actions deploys to `gh-pages` branch
- [ ] Enable GitHub Pages (Settings → Pages → Deploy from `gh-pages` branch)
- [ ] Verify site at `https://datazoode.github.io/polars-statistics/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)