### PR TITLE
Add navigation tabs for clearer section separation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ theme:
         name: Switch to light mode
   features:
     - content.code.copy
+    - navigation.tabs
     - navigation.sections
     - navigation.expand
     - navigation.top


### PR DESCRIPTION
## Summary

- Enables `navigation.tabs` in mkdocs Material theme to render top-level sections (Examples, Statistical Tests, Regression, Model Classes, etc.) as a tab bar across the top of the page
- Makes it much easier to distinguish between major documentation sections at a glance

## Test plan

- [ ] `mkdocs build` succeeds
- [ ] Verify tab bar appears with correct sections on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)