### PR TITLE
Expose Rust-callable API alongside the Python cdylib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ keywords = ["polars", "statistics", "regression", "hypothesis-testing"]
 categories = ["science", "mathematics"]
 
 [lib]
-name = "_polars_statistics"
-crate-type = ["cdylib"]
+name = "polars_statistics"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["python"]
+python = ["dep:pyo3", "dep:numpy"]
 
 [dependencies]
-# Python bindings
-pyo3 = { version = "0.26", features = ["abi3-py39", "extension-module"] }
-numpy = "0.26"
+# Python bindings (gated behind `python` feature)
+pyo3 = { version = "0.26", features = ["abi3-py39", "extension-module"], optional = true }
+numpy = { version = "0.26", optional = true }
 pyo3-polars = { version = "0.25", features = ["derive", "lazy"] }
 
 # Polars
@@ -36,6 +40,7 @@ polars = { version = "0.52", default-features = false, features = [
     "is_in",
     "cross_join",
     "diff",
+    "partition_by",
 ] }
 polars-arrow = "0.52"
 
@@ -56,10 +61,10 @@ thiserror = "2.0.17"
 serde = { version = "1.0.228", features = ["derive"] }
 
 # Regression
-anofox-regression = "0.5.2"
+anofox-regression = "0.5.4"
 
 # Statistics
-anofox-statistics = "0.4.0"
+anofox-statistics = "0.4.1"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 High-performance statistical testing and regression for [Polars](https://pola.rs/) DataFrames, powered by Rust.
 
+Usable from **Python** (as a Polars plugin) and from **Rust** (as an rlib that other Rust crates depend on directly — see [Use from Rust](#use-from-rust)).
+
 ## Features
 
 - **Native Polars Expressions**: Full support for `group_by`, `over`, and lazy evaluation
@@ -17,6 +19,7 @@ High-performance statistical testing and regression for [Polars](https://pola.rs
 - **Regression Models**: OLS, Ridge, Elastic Net, WLS, Quantile, Isotonic, GLMs, ALM (24+ distributions)
 - **Diagnostics**: Condition number, quasi-separation detection for GLMs
 - **Formula Syntax**: R-style formulas with polynomial and interaction effects
+- **Hybrid crate**: `cdylib` (Python wheel) and `rlib` (Rust dependency) from the same source
 - **High Performance**: Rust-powered with zero-copy data transfer
 
 ## Installation
@@ -212,6 +215,71 @@ print(test.summary())
 ```
 
 Available test classes: `TTestInd`, `TTestPaired`, `BrownForsythe`, `YuenTest`, `MannWhitneyU`, `WilcoxonSignedRank`, `KruskalWallis`, `BrunnerMunzel`, `ShapiroWilk`, `DAgostino`.
+
+## Use from Rust
+
+`polars-statistics` builds as both a Python extension (`cdylib`) and a Rust library (`rlib`). Other Rust crates can depend on it directly and call the same statistical and regression code that the Python plugin uses — no Python boundary, no FFI overhead.
+
+### Cargo dependency
+
+```toml
+[dependencies]
+polars = { version = "0.52", features = ["lazy", "partition_by"] }
+polars-statistics = { version = "0.4", default-features = false }
+```
+
+`default-features = false` disables the `python` feature, so pyo3 / numpy are not linked.
+
+### Calling the fit functions
+
+Every Polars expression has a public Rust-callable counterpart named `<name>_fit` that accepts a `&[Series]` input slice matching the expression's input contract and returns a `PolarsResult<Series>` (a one-row struct with the model output).
+
+```rust
+use polars::prelude::*;
+use polars_statistics::expressions::wls_fit;
+
+fn main() -> PolarsResult<()> {
+    let df = df!(
+        "site"   => &["A", "A", "A", "B", "B", "B"],
+        "y"      => &[1.0_f64, 3.0, 5.0, 2.0, 5.0, 8.0],
+        "weight" => &[1.0_f64, 1.0, 1.0, 1.0, 1.0, 1.0],
+        "x1"     => &[0.0_f64, 1.0, 2.0, 0.0, 1.0, 2.0],
+    )?;
+
+    for group in df.partition_by(["site"], true)? {
+        let y  = group.column("y")?.as_materialized_series().clone();
+        let w  = group.column("weight")?.as_materialized_series().clone();
+        let x1 = group.column("x1")?.as_materialized_series().clone();
+        let with_intercept = Series::new("with_intercept".into(), &[true]);
+        let solver         = Series::new("solve_method".into(), &[None::<&str>]);
+
+        let result = wls_fit(&[y, w, with_intercept, solver, x1])?;
+        println!("{result:?}");
+    }
+    Ok(())
+}
+```
+
+The full runnable version is in [`examples/rust_wls.rs`](examples/rust_wls.rs). Run with:
+
+```bash
+cargo run --example rust_wls --no-default-features
+```
+
+### Available fit functions
+
+All ~95 Polars expressions have a `*_fit` Rust entry point in `polars_statistics::expressions`:
+
+- **Regression**: `ols_fit`, `ridge_fit`, `elastic_net_fit`, `wls_fit`, `rls_fit`, `bls_fit`, `quantile_fit`, `isotonic_fit`
+- **GLMs**: `logistic_fit`, `poisson_fit`, `negative_binomial_fit`, `tweedie_fit`, `probit_fit`, `cloglog_fit`, `alm_fit`
+- **Diagnostics**: `condition_number_fit`, `check_binary_separation_fit`, `check_count_sparsity_fit`
+- **Summaries / predictions**: `ols_summary_fit`, `ols_predict_fit`, … (one per model)
+- **Hypothesis tests**: `ttest_ind_fit`, `ttest_paired_fit`, `mann_whitney_fit`, `wilcoxon_fit`, `kruskal_wallis_fit`, `brunner_munzel_fit`, `brown_forsythe_fit`, `yuen_fit`, `shapiro_wilk_fit`, `dagostino_fit`
+- **Correlation**: `pearson_fit`, `spearman_fit`, `kendall_fit`, `distance_cor_fit`, `partial_cor_fit`, `semi_partial_cor_fit`, `icc_fit`
+- **Categorical**: `binom_test_fit`, `prop_test_one_fit`, `prop_test_two_fit`, `chisq_test_fit`, `fisher_exact_fit`, `mcnemar_test_fit`, `cohen_kappa_fit`, `cramers_v_fit`, …
+- **Forecast comparison / TOST / modern**: see `expressions::forecast`, `expressions::tost`, `expressions::modern`.
+
+The input slice layout (which input is `y`, which are scalars, which are `x` columns) is documented above each function — same contract that the Polars plugin uses.
 
 ## Documentation
 

--- a/examples/rust_wls.rs
+++ b/examples/rust_wls.rs
@@ -1,0 +1,45 @@
+//! Per-group WLS via the rlib path — mirrors the per-(site, part) fit loop
+//! used by `kaercher-forecast` and the `anofox-orchestration` metalearner.
+//!
+//! Run with: `cargo run --example rust_wls --no-default-features`
+
+use polars::prelude::*;
+use polars_statistics::expressions::wls_fit;
+
+fn main() -> PolarsResult<()> {
+    // Synthetic panel: two sites, three observations each.
+    // y_i ≈ intercept + slope * x_i, with per-site parameters.
+    let df = df!(
+        "site"   => &["A", "A", "A", "B", "B", "B"],
+        "y"      => &[1.0_f64, 3.0, 5.0, 2.0, 5.0, 8.0],
+        "weight" => &[1.0_f64, 1.0, 1.0, 1.0, 1.0, 1.0],
+        "x1"     => &[0.0_f64, 1.0, 2.0, 0.0, 1.0, 2.0],
+    )?;
+
+    // Per-(site) WLS fit. Each partition is a contiguous DataFrame.
+    let groups = df.partition_by(["site"], /* stable */ true)?;
+
+    for group in groups {
+        let site = group.column("site")?.str()?.get(0).unwrap_or("?");
+
+        // wls_fit input contract:
+        //   [0] y, [1] weights, [2] with_intercept (bool scalar),
+        //   [3] solve_method (str scalar, nullable), [4..] x columns
+        let y = group.column("y")?.as_materialized_series().clone();
+        let w = group.column("weight")?.as_materialized_series().clone();
+        let x1 = group.column("x1")?.as_materialized_series().clone();
+        let with_intercept = Series::new("with_intercept".into(), &[true]);
+        let solver = Series::new("solve_method".into(), &[None::<&str>]);
+
+        let result = wls_fit(&[y, w, with_intercept, solver, x1])?;
+        let fitted = result.struct_()?;
+
+        let intercept = fitted.field_by_name("intercept")?.f64()?.get(0).unwrap_or(f64::NAN);
+        let coefs = fitted.field_by_name("coefficients")?;
+        let r2 = fitted.field_by_name("r_squared")?.f64()?.get(0).unwrap_or(f64::NAN);
+
+        println!("site={site} intercept={intercept:.4} coefs={coefs:?} r2={r2:.4}");
+    }
+
+    Ok(())
+}

--- a/examples/rust_wls.rs
+++ b/examples/rust_wls.rs
@@ -34,9 +34,17 @@ fn main() -> PolarsResult<()> {
         let result = wls_fit(&[y, w, with_intercept, solver, x1])?;
         let fitted = result.struct_()?;
 
-        let intercept = fitted.field_by_name("intercept")?.f64()?.get(0).unwrap_or(f64::NAN);
+        let intercept = fitted
+            .field_by_name("intercept")?
+            .f64()?
+            .get(0)
+            .unwrap_or(f64::NAN);
         let coefs = fitted.field_by_name("coefficients")?;
-        let r2 = fitted.field_by_name("r_squared")?.f64()?.get(0).unwrap_or(f64::NAN);
+        let r2 = fitted
+            .field_by_name("r_squared")?
+            .f64()?
+            .get(0)
+            .unwrap_or(f64::NAN);
 
         println!("site={site} intercept={intercept:.4} coefs={coefs:?} r2={r2:.4}");
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ Changelog = "https://github.com/DataZooDE/polars-statistics/releases"
 python-source = "python"
 module-name = "polars_statistics._polars_statistics"
 bindings = "pyo3"
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "python"]
 strip = true
 
 [tool.pytest.ini_options]

--- a/src/expressions/categorical.rs
+++ b/src/expressions/categorical.rs
@@ -89,9 +89,8 @@ fn association_output(
     Ok(result.into_series())
 }
 
-/// Exact binomial test
-#[polars_expr(output_type_func=proportion_output_dtype)]
-fn pl_binom_test(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_binom_test` expression shim.
+pub fn binom_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let successes = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let n = inputs[1].u32()?.get(0).unwrap_or(1) as usize;
     let p0 = inputs[2].f64()?.get(0).unwrap_or(0.5);
@@ -121,9 +120,14 @@ fn pl_binom_test(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// One-sample proportion test
+/// Exact binomial test
 #[polars_expr(output_type_func=proportion_output_dtype)]
-fn pl_prop_test_one(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_binom_test(inputs: &[Series]) -> PolarsResult<Series> {
+    binom_test_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_prop_test_one` expression shim.
+pub fn prop_test_one_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let successes = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let n = inputs[1].u32()?.get(0).unwrap_or(1) as usize;
     let p0 = inputs[2].f64()?.get(0).unwrap_or(0.5);
@@ -153,9 +157,14 @@ fn pl_prop_test_one(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Two-sample proportion test
+/// One-sample proportion test
 #[polars_expr(output_type_func=proportion_output_dtype)]
-fn pl_prop_test_two(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_prop_test_one(inputs: &[Series]) -> PolarsResult<Series> {
+    prop_test_one_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_prop_test_two` expression shim.
+pub fn prop_test_two_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let successes1 = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let n1 = inputs[1].u32()?.get(0).unwrap_or(1) as usize;
     let successes2 = inputs[2].u32()?.get(0).unwrap_or(0) as usize;
@@ -191,9 +200,14 @@ fn pl_prop_test_two(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Chi-square test for contingency table
-#[polars_expr(output_type_func=chisq_output_dtype)]
-fn pl_chisq_test(inputs: &[Series]) -> PolarsResult<Series> {
+/// Two-sample proportion test
+#[polars_expr(output_type_func=proportion_output_dtype)]
+fn pl_prop_test_two(inputs: &[Series]) -> PolarsResult<Series> {
+    prop_test_two_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_chisq_test` expression shim.
+pub fn chisq_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     // Expects a flattened contingency table with dimensions
     let data = inputs[0].u32()?;
     let n_rows = inputs[1].u32()?.get(0).unwrap_or(2) as usize;
@@ -232,9 +246,14 @@ fn pl_chisq_test(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Chi-square goodness-of-fit test
+/// Chi-square test for contingency table
 #[polars_expr(output_type_func=chisq_output_dtype)]
-fn pl_chisq_goodness_of_fit(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_chisq_test(inputs: &[Series]) -> PolarsResult<Series> {
+    chisq_test_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_chisq_goodness_of_fit` expression shim.
+pub fn chisq_goodness_of_fit_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let observed = inputs[0].u32()?;
     let has_expected = inputs[1].bool()?.get(0).unwrap_or(false);
 
@@ -263,9 +282,14 @@ fn pl_chisq_goodness_of_fit(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// G-test (likelihood ratio test)
+/// Chi-square goodness-of-fit test
 #[polars_expr(output_type_func=chisq_output_dtype)]
-fn pl_g_test(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_chisq_goodness_of_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    chisq_goodness_of_fit_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_g_test` expression shim.
+pub fn g_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let data = inputs[0].u32()?;
     let n_rows = inputs[1].u32()?.get(0).unwrap_or(2) as usize;
     let n_cols = inputs[2].u32()?.get(0).unwrap_or(2) as usize;
@@ -301,9 +325,14 @@ fn pl_g_test(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Fisher's exact test for 2x2 tables
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_fisher_exact(inputs: &[Series]) -> PolarsResult<Series> {
+/// G-test (likelihood ratio test)
+#[polars_expr(output_type_func=chisq_output_dtype)]
+fn pl_g_test(inputs: &[Series]) -> PolarsResult<Series> {
+    g_test_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_fisher_exact` expression shim.
+pub fn fisher_exact_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let a = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let b = inputs[1].u32()?.get(0).unwrap_or(0) as usize;
     let c = inputs[2].u32()?.get(0).unwrap_or(0) as usize;
@@ -339,9 +368,14 @@ fn pl_fisher_exact(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// McNemar's test for paired proportions
-#[polars_expr(output_type_func=chisq_output_dtype)]
-fn pl_mcnemar_test(inputs: &[Series]) -> PolarsResult<Series> {
+/// Fisher's exact test for 2x2 tables
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_fisher_exact(inputs: &[Series]) -> PolarsResult<Series> {
+    fisher_exact_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_mcnemar_test` expression shim.
+pub fn mcnemar_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let a = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let b = inputs[1].u32()?.get(0).unwrap_or(0) as usize;
     let c = inputs[2].u32()?.get(0).unwrap_or(0) as usize;
@@ -359,9 +393,14 @@ fn pl_mcnemar_test(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// McNemar's exact test
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_mcnemar_exact(inputs: &[Series]) -> PolarsResult<Series> {
+/// McNemar's test for paired proportions
+#[polars_expr(output_type_func=chisq_output_dtype)]
+fn pl_mcnemar_test(inputs: &[Series]) -> PolarsResult<Series> {
+    mcnemar_test_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_mcnemar_exact` expression shim.
+pub fn mcnemar_exact_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let a = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let b = inputs[1].u32()?.get(0).unwrap_or(0) as usize;
     let c = inputs[2].u32()?.get(0).unwrap_or(0) as usize;
@@ -396,9 +435,14 @@ fn pl_mcnemar_exact(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Cohen's Kappa for inter-rater agreement
-#[polars_expr(output_type_func=association_output_dtype)]
-fn pl_cohen_kappa(inputs: &[Series]) -> PolarsResult<Series> {
+/// McNemar's exact test
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_mcnemar_exact(inputs: &[Series]) -> PolarsResult<Series> {
+    mcnemar_exact_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_cohen_kappa` expression shim.
+pub fn cohen_kappa_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let data = inputs[0].u32()?;
     let n_categories = inputs[1].u32()?.get(0).unwrap_or(2) as usize;
     let weighted = inputs[2].bool()?.get(0).unwrap_or(false);
@@ -421,9 +465,14 @@ fn pl_cohen_kappa(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Cramér's V for association strength
+/// Cohen's Kappa for inter-rater agreement
 #[polars_expr(output_type_func=association_output_dtype)]
-fn pl_cramers_v(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_cohen_kappa(inputs: &[Series]) -> PolarsResult<Series> {
+    cohen_kappa_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_cramers_v` expression shim.
+pub fn cramers_v_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let data = inputs[0].u32()?;
     let n_rows = inputs[1].u32()?.get(0).unwrap_or(2) as usize;
     let n_cols = inputs[2].u32()?.get(0).unwrap_or(2) as usize;
@@ -455,9 +504,14 @@ fn pl_cramers_v(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Phi coefficient for 2x2 tables
+/// Cramér's V for association strength
 #[polars_expr(output_type_func=association_output_dtype)]
-fn pl_phi_coefficient(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_cramers_v(inputs: &[Series]) -> PolarsResult<Series> {
+    cramers_v_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_phi_coefficient` expression shim.
+pub fn phi_coefficient_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let a = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let b = inputs[1].u32()?.get(0).unwrap_or(0) as usize;
     let c = inputs[2].u32()?.get(0).unwrap_or(0) as usize;
@@ -476,9 +530,14 @@ fn pl_phi_coefficient(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Contingency coefficient
+/// Phi coefficient for 2x2 tables
 #[polars_expr(output_type_func=association_output_dtype)]
-fn pl_contingency_coef(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_phi_coefficient(inputs: &[Series]) -> PolarsResult<Series> {
+    phi_coefficient_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_contingency_coef` expression shim.
+pub fn contingency_coef_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let data = inputs[0].u32()?;
     let n_rows = inputs[1].u32()?.get(0).unwrap_or(2) as usize;
     let n_cols = inputs[2].u32()?.get(0).unwrap_or(2) as usize;
@@ -508,4 +567,10 @@ fn pl_contingency_coef(inputs: &[Series]) -> PolarsResult<Series> {
         ),
         Err(_) => association_output(f64::NAN, f64::NAN, f64::NAN, "contingency_coef"),
     }
+}
+
+/// Contingency coefficient
+#[polars_expr(output_type_func=association_output_dtype)]
+fn pl_contingency_coef(inputs: &[Series]) -> PolarsResult<Series> {
+    contingency_coef_fit(inputs)
 }

--- a/src/expressions/correlation.rs
+++ b/src/expressions/correlation.rs
@@ -58,9 +58,8 @@ fn correlation_error_output(name: &str) -> PolarsResult<Series> {
     Ok(df.into_series())
 }
 
-/// Pearson correlation coefficient
-#[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_pearson(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_pearson` expression shim.
+pub fn pearson_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let conf_level = inputs[2].f64()?.get(0);
@@ -74,9 +73,14 @@ fn pl_pearson(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Spearman rank correlation coefficient
+/// Pearson correlation coefficient
 #[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_spearman(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_pearson(inputs: &[Series]) -> PolarsResult<Series> {
+    pearson_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_spearman` expression shim.
+pub fn spearman_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let conf_level = inputs[2].f64()?.get(0);
@@ -90,9 +94,14 @@ fn pl_spearman(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Kendall's tau correlation coefficient
+/// Spearman rank correlation coefficient
 #[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_kendall(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_spearman(inputs: &[Series]) -> PolarsResult<Series> {
+    spearman_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_kendall` expression shim.
+pub fn kendall_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let variant_str = inputs[2].str()?.get(0).unwrap_or("b");
@@ -112,9 +121,14 @@ fn pl_kendall(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Distance correlation test
+/// Kendall's tau correlation coefficient
 #[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_distance_cor(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_kendall(inputs: &[Series]) -> PolarsResult<Series> {
+    kendall_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_distance_cor` expression shim.
+pub fn distance_cor_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let n_permutations = inputs[2].u32()?.get(0).unwrap_or(999) as usize;
@@ -143,9 +157,14 @@ fn pl_distance_cor(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Partial correlation
+/// Distance correlation test
 #[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_partial_cor(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_distance_cor(inputs: &[Series]) -> PolarsResult<Series> {
+    distance_cor_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_partial_cor` expression shim.
+pub fn partial_cor_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     // Covariates are passed as separate series after x and y
@@ -191,9 +210,14 @@ fn pl_partial_cor(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Semi-partial correlation
+/// Partial correlation
 #[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_semi_partial_cor(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_partial_cor(inputs: &[Series]) -> PolarsResult<Series> {
+    partial_cor_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_semi_partial_cor` expression shim.
+pub fn semi_partial_cor_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let n_covariates = inputs[2].u32()?.get(0).unwrap_or(1) as usize;
@@ -236,11 +260,14 @@ fn pl_semi_partial_cor(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Intraclass correlation coefficient (ICC)
-/// Note: ICC requires a 2D matrix structure (subjects x raters).
-/// This is a placeholder that requires proper matrix input handling.
+/// Semi-partial correlation
 #[polars_expr(output_type_func=correlation_output_dtype)]
-fn pl_icc(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_semi_partial_cor(inputs: &[Series]) -> PolarsResult<Series> {
+    semi_partial_cor_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_icc` expression shim.
+pub fn icc_fit(inputs: &[Series]) -> PolarsResult<Series> {
     // Data is passed as a matrix where each column is a rater
     // For simplicity, we expect groups and values columns
     let values = inputs[0].f64()?;
@@ -265,4 +292,12 @@ fn pl_icc(inputs: &[Series]) -> PolarsResult<Series> {
         [&estimate, &statistic, &p_value, &ci_lower, &ci_upper, &n].into_iter(),
     )?;
     Ok(df.into_series())
+}
+
+/// Intraclass correlation coefficient (ICC)
+/// Note: ICC requires a 2D matrix structure (subjects x raters).
+/// This is a placeholder that requires proper matrix input handling.
+#[polars_expr(output_type_func=correlation_output_dtype)]
+fn pl_icc(inputs: &[Series]) -> PolarsResult<Series> {
+    icc_fit(inputs)
 }

--- a/src/expressions/distributional.rs
+++ b/src/expressions/distributional.rs
@@ -7,9 +7,8 @@ use anofox_statistics::{dagostino_k_squared, shapiro_wilk};
 
 use crate::expressions::output_types::{generic_stats_output, stats_output_dtype};
 
-/// Shapiro-Wilk test for normality
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_shapiro_wilk(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_shapiro_wilk` expression shim.
+pub fn shapiro_wilk_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
 
     let x_vec: Vec<f64> = x.into_no_null_iter().collect();
@@ -20,9 +19,14 @@ fn pl_shapiro_wilk(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// D'Agostino K-squared test for normality
+/// Shapiro-Wilk test for normality
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_dagostino(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_shapiro_wilk(inputs: &[Series]) -> PolarsResult<Series> {
+    shapiro_wilk_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_dagostino` expression shim.
+pub fn dagostino_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
 
     let x_vec: Vec<f64> = x.into_no_null_iter().collect();
@@ -31,4 +35,10 @@ fn pl_dagostino(inputs: &[Series]) -> PolarsResult<Series> {
         Ok(result) => generic_stats_output(result.statistic, result.p_value, "dagostino"),
         Err(_) => generic_stats_output(f64::NAN, f64::NAN, "dagostino"),
     }
+}
+
+/// D'Agostino K-squared test for normality
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_dagostino(inputs: &[Series]) -> PolarsResult<Series> {
+    dagostino_fit(inputs)
 }

--- a/src/expressions/forecast.rs
+++ b/src/expressions/forecast.rs
@@ -35,9 +35,8 @@ fn parse_var_estimator(s: &str) -> VarEstimator {
     }
 }
 
-/// Diebold-Mariano test for comparing forecast accuracy.
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_diebold_mariano(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_diebold_mariano` expression shim.
+pub fn diebold_mariano_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let e1 = inputs[0].f64()?;
     let e2 = inputs[1].f64()?;
     let loss_str = inputs[2].str()?.get(0).unwrap_or("squared");
@@ -58,9 +57,14 @@ fn pl_diebold_mariano(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Permutation t-test for comparing two samples.
+/// Diebold-Mariano test for comparing forecast accuracy.
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_permutation_t_test(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_diebold_mariano(inputs: &[Series]) -> PolarsResult<Series> {
+    diebold_mariano_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_permutation_t_test` expression shim.
+pub fn permutation_t_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let alt_str = inputs[2].str()?.get(0).unwrap_or("two-sided");
@@ -78,9 +82,14 @@ fn pl_permutation_t_test(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Clark-West test for nested model comparison.
+/// Permutation t-test for comparing two samples.
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_clark_west(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_permutation_t_test(inputs: &[Series]) -> PolarsResult<Series> {
+    permutation_t_test_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_clark_west` expression shim.
+pub fn clark_west_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let e1 = inputs[0].f64()?;
     let e2 = inputs[1].f64()?;
     let h = inputs[2].u32()?.get(0).unwrap_or(1) as usize;
@@ -94,6 +103,12 @@ fn pl_clark_west(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
+/// Clark-West test for nested model comparison.
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_clark_west(inputs: &[Series]) -> PolarsResult<Series> {
+    clark_west_fit(inputs)
+}
+
 /// SPA output type with additional fields
 fn spa_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
     let fields = vec![
@@ -105,9 +120,8 @@ fn spa_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
     Ok(Field::new("spa_result".into(), DataType::Struct(fields)))
 }
 
-/// Superior Predictive Ability (SPA) test.
-#[polars_expr(output_type_func=spa_output_dtype)]
-fn pl_spa_test(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_spa_test` expression shim.
+pub fn spa_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let benchmark = inputs[0].f64()?;
     let n_bootstrap = inputs[1].u32()?.get(0).unwrap_or(999) as usize;
     let block_length = inputs[2].f64()?.get(0).unwrap_or(5.0);
@@ -161,6 +175,12 @@ fn pl_spa_test(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
+/// Superior Predictive Ability (SPA) test.
+#[polars_expr(output_type_func=spa_output_dtype)]
+fn pl_spa_test(inputs: &[Series]) -> PolarsResult<Series> {
+    spa_test_fit(inputs)
+}
+
 /// MCS output type
 fn mcs_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
     let fields = vec![
@@ -173,9 +193,8 @@ fn mcs_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
     Ok(Field::new("mcs_result".into(), DataType::Struct(fields)))
 }
 
-/// Model Confidence Set (MCS) test.
-#[polars_expr(output_type_func=mcs_output_dtype)]
-fn pl_model_confidence_set(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_model_confidence_set` expression shim.
+pub fn model_confidence_set_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let alpha = inputs[0].f64()?.get(0).unwrap_or(0.1);
     let stat_str = inputs[1].str()?.get(0).unwrap_or("range");
     let n_bootstrap = inputs[2].u32()?.get(0).unwrap_or(999) as usize;
@@ -230,9 +249,14 @@ fn pl_model_confidence_set(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// MSPE-Adjusted SPA test for nested models.
-#[polars_expr(output_type_func=spa_output_dtype)]
-fn pl_mspe_adjusted(inputs: &[Series]) -> PolarsResult<Series> {
+/// Model Confidence Set (MCS) test.
+#[polars_expr(output_type_func=mcs_output_dtype)]
+fn pl_model_confidence_set(inputs: &[Series]) -> PolarsResult<Series> {
+    model_confidence_set_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_mspe_adjusted` expression shim.
+pub fn mspe_adjusted_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let benchmark = inputs[0].f64()?;
     let n_bootstrap = inputs[1].u32()?.get(0).unwrap_or(999) as usize;
     let block_length = inputs[2].f64()?.get(0).unwrap_or(5.0);
@@ -284,4 +308,10 @@ fn pl_mspe_adjusted(inputs: &[Series]) -> PolarsResult<Series> {
             .map(|ca| ca.into_series())
         }
     }
+}
+
+/// MSPE-Adjusted SPA test for nested models.
+#[polars_expr(output_type_func=spa_output_dtype)]
+fn pl_mspe_adjusted(inputs: &[Series]) -> PolarsResult<Series> {
+    mspe_adjusted_fit(inputs)
 }

--- a/src/expressions/modern.rs
+++ b/src/expressions/modern.rs
@@ -7,9 +7,8 @@ use anofox_statistics::{energy_distance_test_1d, mmd_test_1d};
 
 use crate::expressions::output_types::{generic_stats_output, stats_output_dtype};
 
-/// Energy Distance test for comparing distributions.
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_energy_distance(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_energy_distance` expression shim.
+pub fn energy_distance_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let n_perm = inputs[2].u32()?.get(0).unwrap_or(999) as usize;
@@ -24,10 +23,14 @@ fn pl_energy_distance(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Maximum Mean Discrepancy (MMD) test for comparing distributions.
-/// Uses Gaussian kernel with median heuristic bandwidth.
+/// Energy Distance test for comparing distributions.
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_mmd_test(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_energy_distance(inputs: &[Series]) -> PolarsResult<Series> {
+    energy_distance_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_mmd_test` expression shim.
+pub fn mmd_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let n_perm = inputs[2].u32()?.get(0).unwrap_or(999) as usize;
@@ -40,4 +43,11 @@ fn pl_mmd_test(inputs: &[Series]) -> PolarsResult<Series> {
         Ok(result) => generic_stats_output(result.statistic, result.p_value, "mmd_test"),
         Err(_) => generic_stats_output(f64::NAN, f64::NAN, "mmd_test"),
     }
+}
+
+/// Maximum Mean Discrepancy (MMD) test for comparing distributions.
+/// Uses Gaussian kernel with median heuristic bandwidth.
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_mmd_test(inputs: &[Series]) -> PolarsResult<Series> {
+    mmd_test_fit(inputs)
 }

--- a/src/expressions/nonparametric.rs
+++ b/src/expressions/nonparametric.rs
@@ -18,9 +18,8 @@ fn parse_alternative(s: &str) -> Alternative {
     }
 }
 
-/// Mann-Whitney U test
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_mann_whitney_u(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_mann_whitney_u` expression shim.
+pub fn mann_whitney_u_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let alt_str = inputs[2].str()?.get(0).unwrap_or("two-sided");
@@ -48,9 +47,14 @@ fn pl_mann_whitney_u(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Wilcoxon signed-rank test
+/// Mann-Whitney U test
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_wilcoxon_signed_rank(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_mann_whitney_u(inputs: &[Series]) -> PolarsResult<Series> {
+    mann_whitney_u_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_wilcoxon_signed_rank` expression shim.
+pub fn wilcoxon_signed_rank_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let alt_str = inputs[2].str()?.get(0).unwrap_or("two-sided");
@@ -80,9 +84,14 @@ fn pl_wilcoxon_signed_rank(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Kruskal-Wallis H test
+/// Wilcoxon signed-rank test
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_kruskal_wallis(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_wilcoxon_signed_rank(inputs: &[Series]) -> PolarsResult<Series> {
+    wilcoxon_signed_rank_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_kruskal_wallis` expression shim.
+pub fn kruskal_wallis_fit(inputs: &[Series]) -> PolarsResult<Series> {
     // This takes multiple groups as separate series
     let groups: Vec<Vec<f64>> = inputs
         .iter()
@@ -97,9 +106,14 @@ fn pl_kruskal_wallis(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Brunner-Munzel test (robust alternative to Mann-Whitney)
+/// Kruskal-Wallis H test
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_brunner_munzel(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_kruskal_wallis(inputs: &[Series]) -> PolarsResult<Series> {
+    kruskal_wallis_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_brunner_munzel` expression shim.
+pub fn brunner_munzel_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let alt_str = inputs[2].str()?.get(0).unwrap_or("two-sided");
@@ -114,4 +128,10 @@ fn pl_brunner_munzel(inputs: &[Series]) -> PolarsResult<Series> {
         Ok(result) => generic_stats_output(result.statistic, result.p_value, "brunner_munzel"),
         Err(_) => generic_stats_output(f64::NAN, f64::NAN, "brunner_munzel"),
     }
+}
+
+/// Brunner-Munzel test (robust alternative to Mann-Whitney)
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_brunner_munzel(inputs: &[Series]) -> PolarsResult<Series> {
+    brunner_munzel_fit(inputs)
 }

--- a/src/expressions/parametric.rs
+++ b/src/expressions/parametric.rs
@@ -16,9 +16,8 @@ fn parse_alternative(s: &str) -> Alternative {
     }
 }
 
-/// Independent samples t-test from raw data
-#[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_ttest_ind(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_ttest_ind` expression shim.
+pub fn ttest_ind_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let alt_str = inputs[2].str()?.get(0).unwrap_or("two-sided");
@@ -42,9 +41,14 @@ fn pl_ttest_ind(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Paired samples t-test
+/// Independent samples t-test from raw data
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_ttest_paired(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_ttest_ind(inputs: &[Series]) -> PolarsResult<Series> {
+    ttest_ind_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_ttest_paired` expression shim.
+pub fn ttest_paired_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let alt_str = inputs[2].str()?.get(0).unwrap_or("two-sided");
@@ -69,9 +73,14 @@ fn pl_ttest_paired(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Brown-Forsythe test for equal variances
+/// Paired samples t-test
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_brown_forsythe(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_ttest_paired(inputs: &[Series]) -> PolarsResult<Series> {
+    ttest_paired_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_brown_forsythe` expression shim.
+pub fn brown_forsythe_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
 
@@ -87,9 +96,14 @@ fn pl_brown_forsythe(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Yuen's test for trimmed means (robust alternative to t-test)
+/// Brown-Forsythe test for equal variances
 #[polars_expr(output_type_func=stats_output_dtype)]
-fn pl_yuen_test(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_brown_forsythe(inputs: &[Series]) -> PolarsResult<Series> {
+    brown_forsythe_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_yuen_test` expression shim.
+pub fn yuen_test_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let trim = inputs[2].f64()?.get(0).unwrap_or(0.2);
@@ -105,4 +119,10 @@ fn pl_yuen_test(inputs: &[Series]) -> PolarsResult<Series> {
         Ok(result) => generic_stats_output(result.statistic, result.p_value, "yuen_test"),
         Err(_) => generic_stats_output(f64::NAN, f64::NAN, "yuen_test"),
     }
+}
+
+/// Yuen's test for trimmed means (robust alternative to t-test)
+#[polars_expr(output_type_func=stats_output_dtype)]
+fn pl_yuen_test(inputs: &[Series]) -> PolarsResult<Series> {
+    yuen_test_fit(inputs)
 }

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -398,10 +398,11 @@ fn summary_nan_output() -> PolarsResult<Series> {
 // Linear Regression Expressions
 // ============================================================================
 
-/// OLS regression expression.
-/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2] = solve_method (string or null), inputs[3..] = x columns
-#[polars_expr(output_type_func=linear_regression_output_dtype)]
-fn pl_ols(inputs: &[Series]) -> PolarsResult<Series> {
+/// OLS fit callable from Rust callers.
+///
+/// Input contract: `[y, with_intercept (bool), solve_method (str|null), x_0, x_1, ...]`.
+/// Returns a one-row struct Series matching [`linear_regression_output_dtype`].
+pub fn ols_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[2].str()?.get(0));
 
@@ -437,10 +438,17 @@ fn pl_ols(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Ridge regression expression.
-/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
+/// OLS regression expression.
+/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2] = solve_method (string or null), inputs[3..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
-fn pl_ridge(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_ols(inputs: &[Series]) -> PolarsResult<Series> {
+    ols_fit(inputs)
+}
+
+/// Ridge fit callable from Rust callers.
+///
+/// Input contract: `[y, lambda (f64), with_intercept (bool), solve_method (str|null), x_0, ...]`.
+pub fn ridge_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(1.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[3].str()?.get(0));
@@ -479,10 +487,15 @@ fn pl_ridge(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Elastic Net regression expression.
-/// inputs[0] = y, inputs[1] = lambda, inputs[2] = alpha (L1 ratio), inputs[3] = with_intercept, inputs[4..] = x columns
+/// Ridge regression expression.
+/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
-fn pl_elastic_net(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_ridge(inputs: &[Series]) -> PolarsResult<Series> {
+    ridge_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_elastic_net` expression shim.
+pub fn elastic_net_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(1.0);
     let alpha = inputs[2].f64()?.get(0).unwrap_or(0.5);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -519,10 +532,17 @@ fn pl_elastic_net(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// WLS regression expression.
-/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
+/// Elastic Net regression expression.
+/// inputs[0] = y, inputs[1] = lambda, inputs[2] = alpha (L1 ratio), inputs[3] = with_intercept, inputs[4..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
-fn pl_wls(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_elastic_net(inputs: &[Series]) -> PolarsResult<Series> {
+    elastic_net_fit(inputs)
+}
+
+/// WLS fit callable from Rust callers.
+///
+/// Input contract: `[y, weights (f64), with_intercept (bool), solve_method (str|null), x_0, ...]`.
+pub fn wls_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let weights_series = inputs[1].f64()?;
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[3].str()?.get(0));
@@ -564,10 +584,15 @@ fn pl_wls(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// RLS regression expression.
-/// inputs[0] = y, inputs[1] = forgetting_factor, inputs[2] = with_intercept, inputs[3..] = x columns
+/// WLS regression expression.
+/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
-fn pl_rls(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_wls(inputs: &[Series]) -> PolarsResult<Series> {
+    wls_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_rls` expression shim.
+pub fn rls_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let forgetting_factor = inputs[1].f64()?.get(0).unwrap_or(0.99);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -602,10 +627,15 @@ fn pl_rls(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// BLS (Bounded Least Squares) regression expression.
-/// inputs[0] = y, inputs[1] = lower_bound, inputs[2] = upper_bound, inputs[3] = with_intercept, inputs[4..] = x columns
+/// RLS regression expression.
+/// inputs[0] = y, inputs[1] = forgetting_factor, inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=linear_regression_output_dtype)]
-fn pl_bls(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_rls(inputs: &[Series]) -> PolarsResult<Series> {
+    rls_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_bls` expression shim.
+pub fn bls_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lower_bound = inputs[1].f64()?.get(0);
     let upper_bound = inputs[2].f64()?.get(0);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -647,14 +677,21 @@ fn pl_bls(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
+/// BLS (Bounded Least Squares) regression expression.
+/// inputs[0] = y, inputs[1] = lower_bound, inputs[2] = upper_bound, inputs[3] = with_intercept, inputs[4..] = x columns
+#[polars_expr(output_type_func=linear_regression_output_dtype)]
+fn pl_bls(inputs: &[Series]) -> PolarsResult<Series> {
+    bls_fit(inputs)
+}
+
 // ============================================================================
 // Robust Regression Expressions
 // ============================================================================
 
-/// Quantile regression expression.
-/// inputs[0] = y, inputs[1] = tau, inputs[2] = with_intercept, inputs[3..] = x columns
-#[polars_expr(output_type_func=quantile_output_dtype)]
-fn pl_quantile(inputs: &[Series]) -> PolarsResult<Series> {
+/// Quantile fit callable from Rust callers.
+///
+/// Input contract: `[y, tau (f64), with_intercept (bool), x_0, ...]`.
+pub fn quantile_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let tau = inputs[1].f64()?.get(0).unwrap_or(0.5);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -684,10 +721,15 @@ fn pl_quantile(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Isotonic regression expression.
-/// inputs[0] = y, inputs[1] = x (single feature), inputs[2] = increasing
-#[polars_expr(output_type_func=isotonic_output_dtype)]
-fn pl_isotonic(inputs: &[Series]) -> PolarsResult<Series> {
+/// Quantile regression expression.
+/// inputs[0] = y, inputs[1] = tau, inputs[2] = with_intercept, inputs[3..] = x columns
+#[polars_expr(output_type_func=quantile_output_dtype)]
+fn pl_quantile(inputs: &[Series]) -> PolarsResult<Series> {
+    quantile_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_isotonic` expression shim.
+pub fn isotonic_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let increasing = inputs[2].bool()?.get(0).unwrap_or(true);
 
     // Extract y values
@@ -718,6 +760,13 @@ fn pl_isotonic(inputs: &[Series]) -> PolarsResult<Series> {
         }
         Err(_) => isotonic_nan_output(increasing),
     }
+}
+
+/// Isotonic regression expression.
+/// inputs[0] = y, inputs[1] = x (single feature), inputs[2] = increasing
+#[polars_expr(output_type_func=isotonic_output_dtype)]
+fn pl_isotonic(inputs: &[Series]) -> PolarsResult<Series> {
+    isotonic_fit(inputs)
 }
 
 // ============================================================================
@@ -755,10 +804,8 @@ fn condition_nan_output() -> PolarsResult<Series> {
     condition_output(f64::NAN, f64::NAN, &[], &[], "Unknown", None)
 }
 
-/// Condition number diagnostics expression.
-/// inputs[0] = with_intercept, inputs[1..] = x columns
-#[polars_expr(output_type_func=condition_number_output_dtype)]
-fn pl_condition_number(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_condition_number` expression shim.
+pub fn condition_number_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let with_intercept = inputs[0].bool()?.get(0).unwrap_or(true);
 
     let n_cols = inputs.len() - 1;
@@ -808,6 +855,13 @@ fn pl_condition_number(inputs: &[Series]) -> PolarsResult<Series> {
     )
 }
 
+/// Condition number diagnostics expression.
+/// inputs[0] = with_intercept, inputs[1..] = x columns
+#[polars_expr(output_type_func=condition_number_output_dtype)]
+fn pl_condition_number(inputs: &[Series]) -> PolarsResult<Series> {
+    condition_number_fit(inputs)
+}
+
 /// Convert SeparationType to string.
 fn separation_type_to_string(sep_type: &SeparationType) -> &'static str {
     match sep_type {
@@ -853,10 +907,8 @@ fn separation_default_output() -> PolarsResult<Series> {
     separation_output(&SeparationCheck::default())
 }
 
-/// Check binary response (logistic/probit) data for quasi-separation.
-/// inputs[0] = y (binary), inputs[1..] = x columns
-#[polars_expr(output_type_func=separation_check_output_dtype)]
-fn pl_check_binary_separation(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_check_binary_separation` expression shim.
+pub fn check_binary_separation_fit(inputs: &[Series]) -> PolarsResult<Series> {
     if inputs.is_empty() {
         return separation_default_output();
     }
@@ -900,10 +952,15 @@ fn pl_check_binary_separation(inputs: &[Series]) -> PolarsResult<Series> {
     separation_output(&check)
 }
 
-/// Check count data (Poisson/NegBin) for sparsity-induced separation.
-/// inputs[0] = y (counts), inputs[1..] = x columns
+/// Check binary response (logistic/probit) data for quasi-separation.
+/// inputs[0] = y (binary), inputs[1..] = x columns
 #[polars_expr(output_type_func=separation_check_output_dtype)]
-fn pl_check_count_sparsity(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_check_binary_separation(inputs: &[Series]) -> PolarsResult<Series> {
+    check_binary_separation_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_check_count_sparsity` expression shim.
+pub fn check_count_sparsity_fit(inputs: &[Series]) -> PolarsResult<Series> {
     if inputs.is_empty() {
         return separation_default_output();
     }
@@ -947,14 +1004,19 @@ fn pl_check_count_sparsity(inputs: &[Series]) -> PolarsResult<Series> {
     separation_output(&check)
 }
 
+/// Check count data (Poisson/NegBin) for sparsity-induced separation.
+/// inputs[0] = y (counts), inputs[1..] = x columns
+#[polars_expr(output_type_func=separation_check_output_dtype)]
+fn pl_check_count_sparsity(inputs: &[Series]) -> PolarsResult<Series> {
+    check_count_sparsity_fit(inputs)
+}
+
 // ============================================================================
 // GLM Expressions
 // ============================================================================
 
-/// Logistic regression expression.
-/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
-#[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_logistic(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_logistic` expression shim.
+pub fn logistic_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -984,10 +1046,15 @@ fn pl_logistic(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Poisson regression expression.
+/// Logistic regression expression.
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_poisson(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_logistic(inputs: &[Series]) -> PolarsResult<Series> {
+    logistic_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_poisson` expression shim.
+pub fn poisson_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -1017,10 +1084,15 @@ fn pl_poisson(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Negative Binomial regression expression.
-/// inputs[0] = y, inputs[1] = theta (optional), inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
+/// Poisson regression expression.
+/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_negative_binomial(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_poisson(inputs: &[Series]) -> PolarsResult<Series> {
+    poisson_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_negative_binomial` expression shim.
+pub fn negative_binomial_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let theta = inputs[1].f64()?.get(0);
     let lambda = inputs[2].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -1059,10 +1131,15 @@ fn pl_negative_binomial(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Tweedie regression expression.
-/// inputs[0] = y, inputs[1] = var_power, inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
+/// Negative Binomial regression expression.
+/// inputs[0] = y, inputs[1] = theta (optional), inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
 #[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_tweedie(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_negative_binomial(inputs: &[Series]) -> PolarsResult<Series> {
+    negative_binomial_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tweedie` expression shim.
+pub fn tweedie_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let var_power = inputs[1].f64()?.get(0).unwrap_or(1.5);
     let lambda = inputs[2].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -1097,10 +1174,15 @@ fn pl_tweedie(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Probit regression expression.
-/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
+/// Tweedie regression expression.
+/// inputs[0] = y, inputs[1] = var_power, inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
 #[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_probit(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tweedie(inputs: &[Series]) -> PolarsResult<Series> {
+    tweedie_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_probit` expression shim.
+pub fn probit_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -1130,10 +1212,15 @@ fn pl_probit(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Complementary log-log regression expression.
+/// Probit regression expression.
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_cloglog(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_probit(inputs: &[Series]) -> PolarsResult<Series> {
+    probit_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_cloglog` expression shim.
+pub fn cloglog_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -1163,6 +1250,13 @@ fn pl_cloglog(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
+/// Complementary log-log regression expression.
+/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
+#[polars_expr(output_type_func=glm_output_dtype)]
+fn pl_cloglog(inputs: &[Series]) -> PolarsResult<Series> {
+    cloglog_fit(inputs)
+}
+
 // ============================================================================
 // ALM Expression
 // ============================================================================
@@ -1190,10 +1284,8 @@ fn parse_alm_distribution(s: &str) -> Option<AlmDistribution> {
     }
 }
 
-/// ALM (Augmented Linear Model) expression.
-/// inputs[0] = y, inputs[1] = distribution (string), inputs[2] = with_intercept, inputs[3..] = x columns
-#[polars_expr(output_type_func=glm_output_dtype)]
-fn pl_alm(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_alm` expression shim.
+pub fn alm_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let dist_str = inputs[1].str()?.get(0).unwrap_or("normal");
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -1227,6 +1319,13 @@ fn pl_alm(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
+/// ALM (Augmented Linear Model) expression.
+/// inputs[0] = y, inputs[1] = distribution (string), inputs[2] = with_intercept, inputs[3..] = x columns
+#[polars_expr(output_type_func=glm_output_dtype)]
+fn pl_alm(inputs: &[Series]) -> PolarsResult<Series> {
+    alm_fit(inputs)
+}
+
 // ============================================================================
 // Summary Expressions (Tidy Coefficient Output)
 // ============================================================================
@@ -1243,11 +1342,8 @@ fn build_term_names(n_features: usize, with_intercept: bool) -> Vec<String> {
     terms
 }
 
-/// OLS summary expression - returns tidy coefficient table
-/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2] = solve_method (string or null),
-/// inputs[3] = hc_type (string or null), inputs[4..] = x columns
-#[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_ols_summary(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_ols_summary` expression shim.
+pub fn ols_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[2].str()?.get(0));
     let hc_type = parse_hc_type(inputs[3].str()?.get(0));
@@ -1341,10 +1437,16 @@ fn pl_ols_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Ridge summary expression
-/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
+/// OLS summary expression - returns tidy coefficient table
+/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2] = solve_method (string or null),
+/// inputs[3] = hc_type (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_ridge_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_ols_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    ols_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_ridge_summary` expression shim.
+pub fn ridge_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(1.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[3].str()?.get(0));
@@ -1407,10 +1509,15 @@ fn pl_ridge_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Elastic Net summary expression
-/// inputs[0] = y, inputs[1] = lambda, inputs[2] = alpha, inputs[3] = with_intercept, inputs[4..] = x columns
+/// Ridge summary expression
+/// inputs[0] = y, inputs[1] = lambda, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_elastic_net_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_ridge_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    ridge_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_elastic_net_summary` expression shim.
+pub fn elastic_net_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(1.0);
     let alpha = inputs[2].f64()?.get(0).unwrap_or(0.5);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -1471,10 +1578,15 @@ fn pl_elastic_net_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// WLS summary expression
-/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
+/// Elastic Net summary expression
+/// inputs[0] = y, inputs[1] = lambda, inputs[2] = alpha, inputs[3] = with_intercept, inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_wls_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_elastic_net_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    elastic_net_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_wls_summary` expression shim.
+pub fn wls_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let weights_series = inputs[1].f64()?;
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[3].str()?.get(0));
@@ -1540,10 +1652,15 @@ fn pl_wls_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// RLS summary expression
-/// inputs[0] = y, inputs[1] = forgetting_factor, inputs[2] = with_intercept, inputs[3..] = x columns
+/// WLS summary expression
+/// inputs[0] = y, inputs[1] = weights, inputs[2] = with_intercept, inputs[3] = solve_method (string or null), inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_rls_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_wls_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    wls_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_rls_summary` expression shim.
+pub fn rls_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let forgetting_factor = inputs[1].f64()?.get(0).unwrap_or(0.99);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let n_features = inputs.len() - 3;
@@ -1602,10 +1719,15 @@ fn pl_rls_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// BLS summary expression
-/// inputs[0] = y, inputs[1] = lower_bound, inputs[2] = upper_bound, inputs[3] = with_intercept, inputs[4..] = x columns
+/// RLS summary expression
+/// inputs[0] = y, inputs[1] = forgetting_factor, inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_bls_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_rls_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    rls_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_bls_summary` expression shim.
+pub fn bls_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lower_bound = inputs[1].f64()?.get(0);
     let upper_bound = inputs[2].f64()?.get(0);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -1671,14 +1793,19 @@ fn pl_bls_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
+/// BLS summary expression
+/// inputs[0] = y, inputs[1] = lower_bound, inputs[2] = upper_bound, inputs[3] = with_intercept, inputs[4..] = x columns
+#[polars_expr(output_type_func=summary_output_dtype)]
+fn pl_bls_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    bls_summary_fit(inputs)
+}
+
 // ============================================================================
 // GLM Summary Expressions
 // ============================================================================
 
-/// Logistic summary expression
-/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
-#[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_logistic_summary(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_logistic_summary` expression shim.
+pub fn logistic_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let n_features = inputs.len() - 3;
@@ -1738,10 +1865,15 @@ fn pl_logistic_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Poisson summary expression
+/// Logistic summary expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_poisson_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_logistic_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    logistic_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_poisson_summary` expression shim.
+pub fn poisson_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let n_features = inputs.len() - 3;
@@ -1801,10 +1933,15 @@ fn pl_poisson_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Negative Binomial summary expression
-/// inputs[0] = y, inputs[1] = theta, inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
+/// Poisson summary expression
+/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_negative_binomial_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_poisson_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    poisson_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_negative_binomial_summary` expression shim.
+pub fn negative_binomial_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let theta = inputs[1].f64()?.get(0);
     let lambda = inputs[2].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -1873,10 +2010,15 @@ fn pl_negative_binomial_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Tweedie summary expression
-/// inputs[0] = y, inputs[1] = var_power, inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
+/// Negative Binomial summary expression
+/// inputs[0] = y, inputs[1] = theta, inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_tweedie_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_negative_binomial_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    negative_binomial_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tweedie_summary` expression shim.
+pub fn tweedie_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let var_power = inputs[1].f64()?.get(0).unwrap_or(1.5);
     let lambda = inputs[2].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[3].bool()?.get(0).unwrap_or(true);
@@ -1941,10 +2083,15 @@ fn pl_tweedie_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Probit summary expression
-/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
+/// Tweedie summary expression
+/// inputs[0] = y, inputs[1] = var_power, inputs[2] = lambda (L2 regularization), inputs[3] = with_intercept, inputs[4..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_probit_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tweedie_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    tweedie_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_probit_summary` expression shim.
+pub fn probit_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let n_features = inputs.len() - 3;
@@ -2004,10 +2151,15 @@ fn pl_probit_summary(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Cloglog summary expression
+/// Probit summary expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
 #[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_cloglog_summary(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_probit_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    probit_summary_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_cloglog_summary` expression shim.
+pub fn cloglog_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let n_features = inputs.len() - 3;
@@ -2065,6 +2217,13 @@ fn pl_cloglog_summary(inputs: &[Series]) -> PolarsResult<Series> {
         }
         Err(_) => summary_nan_output(),
     }
+}
+
+/// Cloglog summary expression
+/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3..] = x columns
+#[polars_expr(output_type_func=summary_output_dtype)]
+fn pl_cloglog_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    cloglog_summary_fit(inputs)
 }
 
 // ============================================================================
@@ -2246,11 +2405,8 @@ fn build_xy_with_null_policy(
     }
 }
 
-/// OLS prediction expression - returns predictions with optional intervals.
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
-/// inputs[3] = interval (string or null), inputs[4] = level, inputs[5] = null_policy, inputs[6..] = x columns
-#[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_ols_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_ols_predict` expression shim.
+pub fn ols_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[2].str()?.get(0));
     let interval = inputs[3].str()?.get(0); // None, "confidence", or "prediction"
@@ -2327,11 +2483,16 @@ fn pl_ols_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
     }
 }
 
-/// Ridge prediction expression
+/// OLS prediction expression - returns predictions with optional intervals.
 /// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
-/// inputs[3] = interval, inputs[4] = level, inputs[5] = null_policy, inputs[6] = lambda, inputs[7..] = x columns
+/// inputs[3] = interval (string or null), inputs[4] = level, inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_ridge_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_ols_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    ols_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_ridge_predict` expression shim.
+pub fn ridge_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[2].str()?.get(0));
     let interval = inputs[3].str()?.get(0);
@@ -2406,11 +2567,16 @@ fn pl_ridge_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Se
     }
 }
 
-/// Elastic Net prediction expression
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
-/// inputs[4] = null_policy, inputs[5] = lambda, inputs[6] = alpha, inputs[7..] = x columns
+/// Ridge prediction expression
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
+/// inputs[3] = interval, inputs[4] = level, inputs[5] = null_policy, inputs[6] = lambda, inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_elastic_net_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_ridge_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    ridge_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_elastic_net_predict` expression shim.
+pub fn elastic_net_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let interval = inputs[2].str()?.get(0);
     let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
@@ -2483,11 +2649,16 @@ fn pl_elastic_net_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsRes
     }
 }
 
-/// WLS prediction expression (weights column is inputs[7])
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
-/// inputs[3] = interval, inputs[4] = level, inputs[5] = null_policy, inputs[6] = weights, inputs[7..] = x columns
+/// Elastic Net prediction expression
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
+/// inputs[4] = null_policy, inputs[5] = lambda, inputs[6] = alpha, inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_wls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_elastic_net_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    elastic_net_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_wls_predict` expression shim.
+pub fn wls_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let solve_method = parse_solver_type(inputs[2].str()?.get(0));
     let interval = inputs[3].str()?.get(0);
@@ -2573,11 +2744,16 @@ fn pl_wls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
     }
 }
 
-/// RLS prediction expression
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
-/// inputs[4] = null_policy, inputs[5] = forgetting_factor, inputs[6..] = x columns
+/// WLS prediction expression (weights column is inputs[7])
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = solve_method (string or null),
+/// inputs[3] = interval, inputs[4] = level, inputs[5] = null_policy, inputs[6] = weights, inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_rls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_wls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    wls_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_rls_predict` expression shim.
+pub fn rls_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let interval = inputs[2].str()?.get(0);
     let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
@@ -2648,12 +2824,16 @@ fn pl_rls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
     }
 }
 
-/// BLS prediction expression
+/// RLS prediction expression
 /// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
-/// inputs[4] = null_policy, inputs[5] = lower_bound (or null), inputs[6] = upper_bound (or null),
-/// inputs[7..] = x columns
+/// inputs[4] = null_policy, inputs[5] = forgetting_factor, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_bls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_rls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    rls_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_bls_predict` expression shim.
+pub fn bls_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let interval = inputs[2].str()?.get(0);
     let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
@@ -2729,11 +2909,17 @@ fn pl_bls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
     }
 }
 
-/// Logistic prediction expression
-/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
-/// inputs[5] = null_policy, inputs[6..] = x columns
+/// BLS prediction expression
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
+/// inputs[4] = null_policy, inputs[5] = lower_bound (or null), inputs[6] = upper_bound (or null),
+/// inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_logistic_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_bls_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    bls_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_logistic_predict` expression shim.
+pub fn logistic_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);
@@ -2805,11 +2991,16 @@ fn pl_logistic_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult
     }
 }
 
-/// Poisson prediction expression
+/// Logistic prediction expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
 /// inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_poisson_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_logistic_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    logistic_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_poisson_predict` expression shim.
+pub fn poisson_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);
@@ -2881,11 +3072,16 @@ fn pl_poisson_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<
     }
 }
 
-/// Negative Binomial prediction expression
+/// Poisson prediction expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
 /// inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_negative_binomial_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_poisson_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    poisson_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_negative_binomial_predict` expression shim.
+pub fn negative_binomial_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);
@@ -2957,11 +3153,16 @@ fn pl_negative_binomial_predict(inputs: &[Series], kwargs: PredictKwargs) -> Pol
     }
 }
 
-/// Tweedie prediction expression
+/// Negative Binomial prediction expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
-/// inputs[5] = null_policy, inputs[6] = var_power, inputs[7..] = x columns
+/// inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_tweedie_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_negative_binomial_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    negative_binomial_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tweedie_predict` expression shim.
+pub fn tweedie_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);
@@ -3038,11 +3239,16 @@ fn pl_tweedie_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<
     }
 }
 
-/// Probit prediction expression
+/// Tweedie prediction expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
-/// inputs[5] = null_policy, inputs[6..] = x columns
+/// inputs[5] = null_policy, inputs[6] = var_power, inputs[7..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_probit_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_tweedie_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    tweedie_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_probit_predict` expression shim.
+pub fn probit_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);
@@ -3114,11 +3320,16 @@ fn pl_probit_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<S
     }
 }
 
-/// Cloglog prediction expression
+/// Probit prediction expression
 /// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
 /// inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_cloglog_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_probit_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    probit_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_cloglog_predict` expression shim.
+pub fn cloglog_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);
@@ -3190,11 +3401,16 @@ fn pl_cloglog_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<
     }
 }
 
-/// ALM prediction expression
-/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
-/// inputs[4] = null_policy, inputs[5] = distribution, inputs[6..] = x columns
+/// Cloglog prediction expression
+/// inputs[0] = y, inputs[1] = lambda (L2 regularization), inputs[2] = with_intercept, inputs[3] = interval, inputs[4] = level,
+/// inputs[5] = null_policy, inputs[6..] = x columns
 #[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
-fn pl_alm_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+fn pl_cloglog_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    cloglog_predict_fit(inputs, kwargs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_alm_predict` expression shim.
+pub fn alm_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
     let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
     let interval = inputs[2].str()?.get(0);
     let level = inputs[3].f64()?.get(0).unwrap_or(0.95);
@@ -3270,14 +3486,20 @@ fn pl_alm_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Seri
     }
 }
 
+/// ALM prediction expression
+/// inputs[0] = y, inputs[1] = with_intercept, inputs[2] = interval, inputs[3] = level,
+/// inputs[4] = null_policy, inputs[5] = distribution, inputs[6..] = x columns
+#[polars_expr(output_type_func_with_kwargs=predict_output_dtype_with_prefix)]
+fn pl_alm_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+    alm_predict_fit(inputs, kwargs)
+}
+
 // ============================================================================
 // GLM Summary Expressions
 // ============================================================================
 
-/// ALM summary expression
-/// inputs[0] = y, inputs[1] = distribution, inputs[2] = with_intercept, inputs[3..] = x columns
-#[polars_expr(output_type_func=summary_output_dtype)]
-fn pl_alm_summary(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_alm_summary` expression shim.
+pub fn alm_summary_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let dist_str = inputs[1].str()?.get(0).unwrap_or("normal");
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let n_features = inputs.len() - 3;
@@ -3339,6 +3561,13 @@ fn pl_alm_summary(inputs: &[Series]) -> PolarsResult<Series> {
         }
         Err(_) => summary_nan_output(),
     }
+}
+
+/// ALM summary expression
+/// inputs[0] = y, inputs[1] = distribution, inputs[2] = with_intercept, inputs[3..] = x columns
+#[polars_expr(output_type_func=summary_output_dtype)]
+fn pl_alm_summary(inputs: &[Series]) -> PolarsResult<Series> {
+    alm_summary_fit(inputs)
 }
 
 // ============================================================================
@@ -3504,17 +3733,8 @@ fn aid_nan_output() -> PolarsResult<Series> {
     )
 }
 
-/// Automatic Identification of Demand (AID) classifier.
-///
-/// Classifies demand patterns as regular or intermittent and selects the
-/// best-fitting distribution.
-///
-/// # Arguments
-/// * inputs[0] - y: demand time series
-/// * inputs[1] - intermittent_threshold: threshold for classifying as intermittent (0.0 to 1.0)
-/// * inputs[2] - detect_anomalies: whether to detect anomalies (boolean)
-#[polars_expr(output_type_func=aid_output_dtype)]
-fn pl_aid(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_aid` expression shim.
+pub fn aid_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let intermittent_threshold = inputs[1].f64()?.get(0).unwrap_or(0.3);
     let detect_anomalies = inputs[2].bool()?.get(0).unwrap_or(true);
 
@@ -3548,6 +3768,20 @@ fn pl_aid(inputs: &[Series]) -> PolarsResult<Series> {
         result.n_observations as u32,
         &anomaly_counts,
     )
+}
+
+/// Automatic Identification of Demand (AID) classifier.
+///
+/// Classifies demand patterns as regular or intermittent and selects the
+/// best-fitting distribution.
+///
+/// # Arguments
+/// * inputs[0] - y: demand time series
+/// * inputs[1] - intermittent_threshold: threshold for classifying as intermittent (0.0 to 1.0)
+/// * inputs[2] - detect_anomalies: whether to detect anomalies (boolean)
+#[polars_expr(output_type_func=aid_output_dtype)]
+fn pl_aid(inputs: &[Series]) -> PolarsResult<Series> {
+    aid_fit(inputs)
 }
 
 // ============================================================================
@@ -3609,13 +3843,8 @@ fn aid_anomalies_nan_output(n_rows: usize) -> PolarsResult<Series> {
     )
 }
 
-/// AID Anomalies expression - returns per-observation anomaly flags.
-///
-/// # Arguments
-/// * inputs[0] - y: demand time series
-/// * inputs[1] - intermittent_threshold: threshold for classifying as intermittent (0.0 to 1.0)
-#[polars_expr(output_type_func=aid_anomalies_output_dtype)]
-fn pl_aid_anomalies(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_aid_anomalies` expression shim.
+pub fn aid_anomalies_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let intermittent_threshold = inputs[1].f64()?.get(0).unwrap_or(0.3);
 
     let y_series = inputs[0].f64()?;
@@ -3661,6 +3890,16 @@ fn pl_aid_anomalies(inputs: &[Series]) -> PolarsResult<Series> {
         high_outlier,
         low_outlier,
     )
+}
+
+/// AID Anomalies expression - returns per-observation anomaly flags.
+///
+/// # Arguments
+/// * inputs[0] - y: demand time series
+/// * inputs[1] - intermittent_threshold: threshold for classifying as intermittent (0.0 to 1.0)
+#[polars_expr(output_type_func=aid_anomalies_output_dtype)]
+fn pl_aid_anomalies(inputs: &[Series]) -> PolarsResult<Series> {
+    aid_anomalies_fit(inputs)
 }
 
 // ============================================================================
@@ -3724,21 +3963,8 @@ fn lm_dynamic_nan_output() -> PolarsResult<Series> {
     lm_dynamic_output(None, &[], f64::NAN, f64::NAN, f64::NAN, f64::NAN, 0)
 }
 
-/// Dynamic Linear Model regression.
-///
-/// A time-varying parameter model that combines multiple candidate regression
-/// models using pointwise information criteria weighting.
-///
-/// # Arguments
-/// * inputs[0] - y: target variable
-/// * inputs[1] - ic: information criterion ("aic", "aicc", "bic")
-/// * inputs[2] - distribution: error distribution
-/// * inputs[3] - lowess_span: LOWESS smoothing span (0.0 to disable, 0.05-1.0 to enable)
-/// * inputs[4] - max_models: maximum number of candidate models
-/// * inputs[5] - with_intercept: whether to include intercept
-/// * inputs[6..] - x: feature variables
-#[polars_expr(output_type_func=lm_dynamic_output_dtype)]
-fn pl_lm_dynamic(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_lm_dynamic` expression shim.
+pub fn lm_dynamic_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let ic_str = inputs[1].str()?.get(0).unwrap_or("aicc");
     let dist_str = inputs[2].str()?.get(0).unwrap_or("normal");
     let lowess_span = inputs[3].f64()?.get(0).unwrap_or(0.3);
@@ -3791,4 +4017,22 @@ fn pl_lm_dynamic(inputs: &[Series]) -> PolarsResult<Series> {
         }
         Err(_) => lm_dynamic_nan_output(),
     }
+}
+
+/// Dynamic Linear Model regression.
+///
+/// A time-varying parameter model that combines multiple candidate regression
+/// models using pointwise information criteria weighting.
+///
+/// # Arguments
+/// * inputs[0] - y: target variable
+/// * inputs[1] - ic: information criterion ("aic", "aicc", "bic")
+/// * inputs[2] - distribution: error distribution
+/// * inputs[3] - lowess_span: LOWESS smoothing span (0.0 to disable, 0.05-1.0 to enable)
+/// * inputs[4] - max_models: maximum number of candidate models
+/// * inputs[5] - with_intercept: whether to include intercept
+/// * inputs[6..] - x: feature variables
+#[polars_expr(output_type_func=lm_dynamic_output_dtype)]
+fn pl_lm_dynamic(inputs: &[Series]) -> PolarsResult<Series> {
+    lm_dynamic_fit(inputs)
 }

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -3081,7 +3081,10 @@ fn pl_poisson_predict(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<
 }
 
 /// Public Rust-callable variant. Same input contract as the `pl_negative_binomial_predict` expression shim.
-pub fn negative_binomial_predict_fit(inputs: &[Series], kwargs: PredictKwargs) -> PolarsResult<Series> {
+pub fn negative_binomial_predict_fit(
+    inputs: &[Series],
+    kwargs: PredictKwargs,
+) -> PolarsResult<Series> {
     let lambda = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let with_intercept = inputs[2].bool()?.get(0).unwrap_or(true);
     let interval = inputs[3].str()?.get(0);

--- a/src/expressions/tost.rs
+++ b/src/expressions/tost.rs
@@ -82,9 +82,8 @@ fn parse_bounds(bounds_type: &str, delta: f64, lower: f64, upper: f64) -> Equiva
     }
 }
 
-/// One-sample TOST equivalence test
-#[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_t_test_one_sample(inputs: &[Series]) -> PolarsResult<Series> {
+/// Public Rust-callable variant. Same input contract as the `pl_tost_t_test_one_sample` expression shim.
+pub fn tost_t_test_one_sample_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let mu = inputs[1].f64()?.get(0).unwrap_or(0.0);
     let bounds_type = inputs[2].str()?.get(0).unwrap_or("symmetric");
@@ -102,9 +101,14 @@ fn pl_tost_t_test_one_sample(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Two-sample TOST equivalence test
+/// One-sample TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_t_test_two_sample(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_t_test_one_sample(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_t_test_one_sample_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_t_test_two_sample` expression shim.
+pub fn tost_t_test_two_sample_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let bounds_type = inputs[2].str()?.get(0).unwrap_or("symmetric");
@@ -124,9 +128,14 @@ fn pl_tost_t_test_two_sample(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Paired-samples TOST equivalence test
+/// Two-sample TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_t_test_paired(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_t_test_two_sample(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_t_test_two_sample_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_t_test_paired` expression shim.
+pub fn tost_t_test_paired_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let bounds_type = inputs[2].str()?.get(0).unwrap_or("symmetric");
@@ -145,9 +154,14 @@ fn pl_tost_t_test_paired(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Correlation TOST equivalence test
+/// Paired-samples TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_correlation(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_t_test_paired(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_t_test_paired_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_correlation` expression shim.
+pub fn tost_correlation_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let method_str = inputs[2].str()?.get(0).unwrap_or("pearson");
@@ -174,9 +188,14 @@ fn pl_tost_correlation(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// One-proportion TOST equivalence test
+/// Correlation TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_prop_one(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_correlation(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_correlation_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_prop_one` expression shim.
+pub fn tost_prop_one_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let successes = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let n = inputs[1].u32()?.get(0).unwrap_or(1) as usize;
     let p0 = inputs[2].f64()?.get(0).unwrap_or(0.5);
@@ -194,9 +213,14 @@ fn pl_tost_prop_one(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Two-proportion TOST equivalence test
+/// One-proportion TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_prop_two(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_prop_one(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_prop_one_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_prop_two` expression shim.
+pub fn tost_prop_two_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let successes1 = inputs[0].u32()?.get(0).unwrap_or(0) as usize;
     let n1 = inputs[1].u32()?.get(0).unwrap_or(1) as usize;
     let successes2 = inputs[2].u32()?.get(0).unwrap_or(0) as usize;
@@ -215,9 +239,14 @@ fn pl_tost_prop_two(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Wilcoxon paired-samples TOST equivalence test
+/// Two-proportion TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_wilcoxon_paired(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_prop_two(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_prop_two_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_wilcoxon_paired` expression shim.
+pub fn tost_wilcoxon_paired_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let bounds_type = inputs[2].str()?.get(0).unwrap_or("symmetric");
@@ -236,9 +265,14 @@ fn pl_tost_wilcoxon_paired(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Wilcoxon two-sample TOST equivalence test
+/// Wilcoxon paired-samples TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_wilcoxon_two_sample(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_wilcoxon_paired(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_wilcoxon_paired_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_wilcoxon_two_sample` expression shim.
+pub fn tost_wilcoxon_two_sample_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let bounds_type = inputs[2].str()?.get(0).unwrap_or("symmetric");
@@ -257,9 +291,14 @@ fn pl_tost_wilcoxon_two_sample(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Bootstrap TOST equivalence test
+/// Wilcoxon two-sample TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_bootstrap(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_wilcoxon_two_sample(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_wilcoxon_two_sample_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_bootstrap` expression shim.
+pub fn tost_bootstrap_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let bounds_type = inputs[2].str()?.get(0).unwrap_or("symmetric");
@@ -280,9 +319,14 @@ fn pl_tost_bootstrap(inputs: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-/// Yuen TOST equivalence test (trimmed means)
+/// Bootstrap TOST equivalence test
 #[polars_expr(output_type_func=tost_output_dtype)]
-fn pl_tost_yuen(inputs: &[Series]) -> PolarsResult<Series> {
+fn pl_tost_bootstrap(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_bootstrap_fit(inputs)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_tost_yuen` expression shim.
+pub fn tost_yuen_fit(inputs: &[Series]) -> PolarsResult<Series> {
     let x = inputs[0].f64()?;
     let y = inputs[1].f64()?;
     let trim = inputs[2].f64()?.get(0).unwrap_or(0.2);
@@ -300,4 +344,10 @@ fn pl_tost_yuen(inputs: &[Series]) -> PolarsResult<Series> {
         Ok(result) => tost_output(&result, "tost_yuen"),
         Err(_) => tost_error_output("tost_yuen"),
     }
+}
+
+/// Yuen TOST equivalence test (trimmed means)
+#[polars_expr(output_type_func=tost_output_dtype)]
+fn pl_tost_yuen(inputs: &[Series]) -> PolarsResult<Series> {
+    tost_yuen_fit(inputs)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,31 @@
 //! polars-statistics: Statistical testing and regression for Polars DataFrames.
 //!
-//! This crate provides Python bindings for statistical analysis with Polars,
-//! wrapping the `anofox-regression` and `anofox-statistics` Rust libraries.
+//! This crate provides Polars expressions wrapping `anofox-regression` and
+//! `anofox-statistics`. It is consumable two ways:
+//!
+//! - As an **rlib** by other Rust crates: `polars-statistics = "0.4"` and
+//!   `use polars_statistics::expressions::*;` — no pyo3 linkage, no `python` feature.
+//! - As a **cdylib** Python extension: built by `maturin` with the default
+//!   `python` feature, producing the `_polars_statistics` module.
 
-use pyo3::prelude::*;
-use pyo3_polars::PolarsAllocator;
+pub mod expressions;
 
-mod expressions;
+#[cfg(feature = "python")]
 mod pymodels;
+#[cfg(feature = "python")]
 mod utils;
 
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use pyo3_polars::PolarsAllocator;
+
+#[cfg(feature = "python")]
 #[global_allocator]
 static ALLOC: PolarsAllocator = PolarsAllocator::new();
 
 /// Python module for polars-statistics.
+#[cfg(feature = "python")]
 #[pymodule]
 fn _polars_statistics(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Linear Models

--- a/tests/rust_api.rs
+++ b/tests/rust_api.rs
@@ -122,13 +122,15 @@ fn linear_regression_fits() {
             .get(0)
             .unwrap();
         let coefs_field = st.field_by_name("coefficients").unwrap();
-        let coefs_inner = coefs_field
-            .list()
-            .unwrap()
-            .get_as_series(0)
-            .unwrap();
+        let coefs_inner = coefs_field.list().unwrap().get_as_series(0).unwrap();
         let slope = coefs_inner.f64().unwrap().get(0).unwrap();
-        let r2 = st.field_by_name("r_squared").unwrap().f64().unwrap().get(0).unwrap();
+        let r2 = st
+            .field_by_name("r_squared")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
         assert!(
             (intercept - 1.0).abs() < 1e-6,
             "OLS intercept ~ 1.0, got {intercept}"
@@ -152,7 +154,13 @@ fn linear_regression_fits() {
         ];
         let out = wls_fit(&inputs).expect("wls_fit failed");
         let st = out.struct_().unwrap();
-        let intercept = st.field_by_name("intercept").unwrap().f64().unwrap().get(0).unwrap();
+        let intercept = st
+            .field_by_name("intercept")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
         let coefs_inner = st
             .field_by_name("coefficients")
             .unwrap()
@@ -161,7 +169,10 @@ fn linear_regression_fits() {
             .get_as_series(0)
             .unwrap();
         let slope = coefs_inner.f64().unwrap().get(0).unwrap();
-        assert!((intercept - 1.0).abs() < 1e-6, "WLS intercept ~ 1.0, got {intercept}");
+        assert!(
+            (intercept - 1.0).abs() < 1e-6,
+            "WLS intercept ~ 1.0, got {intercept}"
+        );
         assert!((slope - 2.0).abs() < 1e-6, "WLS slope ~ 2.0, got {slope}");
         assert_n_obs_nonzero(&out, "n_observations");
     }
@@ -179,7 +190,13 @@ fn linear_regression_fits() {
         ];
         let out = ridge_fit(&inputs).expect("ridge_fit failed");
         let st = out.struct_().unwrap();
-        let intercept = st.field_by_name("intercept").unwrap().f64().unwrap().get(0).unwrap();
+        let intercept = st
+            .field_by_name("intercept")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
         let coefs_inner = st
             .field_by_name("coefficients")
             .unwrap()
@@ -211,7 +228,13 @@ fn linear_regression_fits() {
         ];
         let out = quantile_fit(&inputs).expect("quantile_fit failed");
         let st = out.struct_().unwrap();
-        let intercept = st.field_by_name("intercept").unwrap().f64().unwrap().get(0).unwrap();
+        let intercept = st
+            .field_by_name("intercept")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
         let coefs_inner = st
             .field_by_name("coefficients")
             .unwrap()
@@ -521,8 +544,8 @@ fn glm_fits() {
         ];
         let out = negative_binomial_fit(&inputs).expect("negative_binomial_fit failed");
         assert_n_obs_nonzero(&out, "n_observations");
-        let _ = negative_binomial_summary_fit(&inputs)
-            .expect("negative_binomial_summary_fit failed");
+        let _ =
+            negative_binomial_summary_fit(&inputs).expect("negative_binomial_summary_fit failed");
     }
 
     // tweedie_fit: y, var_power, lambda, with_intercept, x...
@@ -713,16 +736,13 @@ fn diagnostic_fits() {
 
     // check_binary_separation_fit: y (binary), x columns.
     {
-        let y: Vec<f64> = (0..20)
-            .map(|i| if i >= 10 { 1.0 } else { 0.0 })
-            .collect();
+        let y: Vec<f64> = (0..20).map(|i| if i >= 10 { 1.0 } else { 0.0 }).collect();
         let inputs = vec![
             series_f64("y", &y),
             series_f64("x1", &x1),
             series_f64("x2", &x2),
         ];
-        let out =
-            check_binary_separation_fit(&inputs).expect("check_binary_separation_fit failed");
+        let out = check_binary_separation_fit(&inputs).expect("check_binary_separation_fit failed");
         let st = out.struct_().unwrap();
         let _has = st.field_by_name("has_separation").unwrap();
     }
@@ -1110,12 +1130,8 @@ fn categorical_fits() {
 #[test]
 fn forecast_fits() {
     // Two error series of length 50.
-    let e1: Vec<f64> = (0..50)
-        .map(|i| (i as f64).sin() * 0.5 + 0.1)
-        .collect();
-    let e2: Vec<f64> = (0..50)
-        .map(|i| (i as f64).cos() * 0.5 + 0.15)
-        .collect();
+    let e1: Vec<f64> = (0..50).map(|i| (i as f64).sin() * 0.5 + 0.1).collect();
+    let e2: Vec<f64> = (0..50).map(|i| (i as f64).cos() * 0.5 + 0.15).collect();
     let e3: Vec<f64> = (0..50)
         .map(|i| ((i as f64) * 0.7).sin() * 0.4 + 0.2)
         .collect();
@@ -1350,8 +1366,7 @@ fn tost_fits() {
             scalar_f64("upper", 5.0),
             scalar_f64("alpha", 0.05),
         ];
-        let _ =
-            tost_wilcoxon_two_sample_fit(&inputs).expect("tost_wilcoxon_two_sample_fit failed");
+        let _ = tost_wilcoxon_two_sample_fit(&inputs).expect("tost_wilcoxon_two_sample_fit failed");
     }
 
     // tost_bootstrap_fit: x, y, bounds_type, delta, lower, upper, alpha, n_bootstrap, seed
@@ -1396,7 +1411,13 @@ fn dynamic_model_fits() {
     {
         // Intermittent count series with occasional zeros.
         let y: Vec<f64> = (0..30)
-            .map(|i| if i % 3 == 0 { 0.0 } else { (i as f64) % 5.0 + 1.0 })
+            .map(|i| {
+                if i % 3 == 0 {
+                    0.0
+                } else {
+                    (i as f64) % 5.0 + 1.0
+                }
+            })
             .collect();
         let inputs = vec![
             series_f64("y", &y),
@@ -1410,7 +1431,13 @@ fn dynamic_model_fits() {
     // aid_anomalies_fit: y, intermittent_threshold
     {
         let y: Vec<f64> = (0..30)
-            .map(|i| if i % 3 == 0 { 0.0 } else { (i as f64) % 5.0 + 1.0 })
+            .map(|i| {
+                if i % 3 == 0 {
+                    0.0
+                } else {
+                    (i as f64) % 5.0 + 1.0
+                }
+            })
             .collect();
         let inputs = vec![
             series_f64("y", &y),

--- a/tests/rust_api.rs
+++ b/tests/rust_api.rs
@@ -1,0 +1,1452 @@
+//! Integration tests for the public Rust API exposed by `polars_statistics::expressions`.
+//!
+//! These tests exercise every `*_fit` function reachable from a downstream Rust crate
+//! via the rlib path. They must compile and pass with:
+//!
+//! ```text
+//! cargo test --no-default-features --test rust_api
+//! ```
+//!
+//! Test depth:
+//! - The four headline regressors (OLS / WLS / Ridge / Quantile) are validated against
+//!   known coefficients on synthetic linear data.
+//! - All other `*_fit` functions are smoke-tested for reachability and no-panic
+//!   behaviour on legitimate inputs.
+
+use polars::prelude::*;
+use polars_statistics::expressions::*;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Synthetic data: y = 1.0 + 2.0 * x with no noise. 20 points.
+fn linear_xy() -> (Vec<f64>, Vec<f64>) {
+    let x: Vec<f64> = (0..20).map(|i| i as f64).collect();
+    let y: Vec<f64> = x.iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+    (x, y)
+}
+
+/// Two moderately-correlated samples, length 25.
+fn two_samples() -> (Vec<f64>, Vec<f64>) {
+    let a: Vec<f64> = (0..25).map(|i| (i as f64) * 0.5 + 1.0).collect();
+    let b: Vec<f64> = (0..25).map(|i| (i as f64) * 0.5 + 1.3).collect();
+    (a, b)
+}
+
+fn series_f64(name: &str, vals: &[f64]) -> Series {
+    Series::new(name.into(), vals)
+}
+
+fn scalar_f64(name: &str, v: f64) -> Series {
+    Series::new(name.into(), &[v])
+}
+
+fn scalar_bool(name: &str, v: bool) -> Series {
+    Series::new(name.into(), &[v])
+}
+
+fn scalar_str(name: &str, v: &str) -> Series {
+    Series::new(name.into(), &[v])
+}
+
+fn scalar_str_null(name: &str) -> Series {
+    Series::new(name.into(), &[None::<&str>])
+}
+
+fn scalar_u32(name: &str, v: u32) -> Series {
+    Series::new(name.into(), &[v])
+}
+
+fn scalar_u64(name: &str, v: u64) -> Series {
+    Series::new(name.into(), &[v])
+}
+
+fn scalar_u64_null(name: &str) -> Series {
+    Series::new(name.into(), &[None::<u64>])
+}
+
+/// Helper to assert that a struct Series has a `n_observations` field > 0.
+fn assert_n_obs_nonzero(s: &Series, field: &str) {
+    let ca = s.struct_().expect("expected struct series");
+    let n_series = ca
+        .field_by_name(field)
+        .unwrap_or_else(|_| panic!("missing field `{field}`"));
+    let n = n_series
+        .u32()
+        .expect("n_observations is u32")
+        .get(0)
+        .unwrap_or(0);
+    assert!(n > 0, "expected `{field}` > 0, got {n}");
+}
+
+/// Helper: assert a struct field f64 is non-NaN (proves the fit produced a value).
+fn assert_f64_finite_or_zero(s: &Series, field: &str) {
+    let ca = s.struct_().expect("expected struct series");
+    let f = ca
+        .field_by_name(field)
+        .unwrap_or_else(|_| panic!("missing field `{field}`"));
+    let v = f.f64().expect("expected f64 column").get(0);
+    // We accept any value (including NaN) as long as the call didn't panic — but
+    // for the headline asserts below we use the dedicated helpers.
+    let _ = v;
+}
+
+// =============================================================================
+// Linear regression (OLS / Ridge / Elastic Net / WLS / RLS / BLS) +
+// Quantile / Isotonic + their *_summary_fit + *_predict_fit variants
+// =============================================================================
+
+#[test]
+fn linear_regression_fits() {
+    let (x, y) = linear_xy();
+    let n = x.len();
+
+    // -----------------------------------------------------------------
+    // OLS: assert known coefficients (intercept ~= 1.0, slope ~= 2.0).
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            series_f64("x1", &x),
+        ];
+        let out = ols_fit(&inputs).expect("ols_fit failed");
+        let st = out.struct_().unwrap();
+        let intercept = st
+            .field_by_name("intercept")
+            .unwrap()
+            .f64()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        let coefs_field = st.field_by_name("coefficients").unwrap();
+        let coefs_inner = coefs_field
+            .list()
+            .unwrap()
+            .get_as_series(0)
+            .unwrap();
+        let slope = coefs_inner.f64().unwrap().get(0).unwrap();
+        let r2 = st.field_by_name("r_squared").unwrap().f64().unwrap().get(0).unwrap();
+        assert!(
+            (intercept - 1.0).abs() < 1e-6,
+            "OLS intercept ~ 1.0, got {intercept}"
+        );
+        assert!((slope - 2.0).abs() < 1e-6, "OLS slope ~ 2.0, got {slope}");
+        assert!((r2 - 1.0).abs() < 1e-6, "OLS R^2 ~ 1.0, got {r2}");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // WLS: same exact-fit data, all-unit weights.
+    // -----------------------------------------------------------------
+    {
+        let w = vec![1.0_f64; n];
+        let inputs = vec![
+            series_f64("y", &y),
+            series_f64("w", &w),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            series_f64("x1", &x),
+        ];
+        let out = wls_fit(&inputs).expect("wls_fit failed");
+        let st = out.struct_().unwrap();
+        let intercept = st.field_by_name("intercept").unwrap().f64().unwrap().get(0).unwrap();
+        let coefs_inner = st
+            .field_by_name("coefficients")
+            .unwrap()
+            .list()
+            .unwrap()
+            .get_as_series(0)
+            .unwrap();
+        let slope = coefs_inner.f64().unwrap().get(0).unwrap();
+        assert!((intercept - 1.0).abs() < 1e-6, "WLS intercept ~ 1.0, got {intercept}");
+        assert!((slope - 2.0).abs() < 1e-6, "WLS slope ~ 2.0, got {slope}");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // Ridge: small lambda -> close to OLS coefficients.
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("lambda", 1e-6),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            series_f64("x1", &x),
+        ];
+        let out = ridge_fit(&inputs).expect("ridge_fit failed");
+        let st = out.struct_().unwrap();
+        let intercept = st.field_by_name("intercept").unwrap().f64().unwrap().get(0).unwrap();
+        let coefs_inner = st
+            .field_by_name("coefficients")
+            .unwrap()
+            .list()
+            .unwrap()
+            .get_as_series(0)
+            .unwrap();
+        let slope = coefs_inner.f64().unwrap().get(0).unwrap();
+        assert!(
+            (intercept - 1.0).abs() < 1e-3,
+            "Ridge intercept ~ 1.0 (small lambda), got {intercept}"
+        );
+        assert!(
+            (slope - 2.0).abs() < 1e-3,
+            "Ridge slope ~ 2.0 (small lambda), got {slope}"
+        );
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // Quantile (median, tau = 0.5).
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("tau", 0.5),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let out = quantile_fit(&inputs).expect("quantile_fit failed");
+        let st = out.struct_().unwrap();
+        let intercept = st.field_by_name("intercept").unwrap().f64().unwrap().get(0).unwrap();
+        let coefs_inner = st
+            .field_by_name("coefficients")
+            .unwrap()
+            .list()
+            .unwrap()
+            .get_as_series(0)
+            .unwrap();
+        let slope = coefs_inner.f64().unwrap().get(0).unwrap();
+        assert!(
+            (intercept - 1.0).abs() < 1e-3,
+            "Quantile (median) intercept ~ 1.0, got {intercept}"
+        );
+        assert!(
+            (slope - 2.0).abs() < 1e-3,
+            "Quantile (median) slope ~ 2.0, got {slope}"
+        );
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // Elastic Net (smoke test).
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("lambda", 0.01),
+            scalar_f64("alpha", 0.5),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let out = elastic_net_fit(&inputs).expect("elastic_net_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // RLS (smoke test).
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("forgetting_factor", 0.99),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let out = rls_fit(&inputs).expect("rls_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // BLS (smoke test).
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("lower_bound", -10.0),
+            scalar_f64("upper_bound", 10.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let out = bls_fit(&inputs).expect("bls_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // Isotonic (single feature, strictly increasing).
+    // -----------------------------------------------------------------
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            series_f64("x", &x),
+            scalar_bool("increasing", true),
+        ];
+        let out = isotonic_fit(&inputs).expect("isotonic_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // -----------------------------------------------------------------
+    // Summary variants (tidy coefficient output).
+    // -----------------------------------------------------------------
+    {
+        // ols_summary: y, with_intercept, solve_method, hc_type, x...
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            scalar_str_null("hc_type"),
+            series_f64("x1", &x),
+        ];
+        let _ = ols_summary_fit(&inputs).expect("ols_summary_fit failed");
+    }
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("lambda", 0.1),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            series_f64("x1", &x),
+        ];
+        let _ = ridge_summary_fit(&inputs).expect("ridge_summary_fit failed");
+    }
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("lambda", 0.1),
+            scalar_f64("alpha", 0.5),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let _ = elastic_net_summary_fit(&inputs).expect("elastic_net_summary_fit failed");
+    }
+    {
+        let w = vec![1.0_f64; n];
+        let inputs = vec![
+            series_f64("y", &y),
+            series_f64("w", &w),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            series_f64("x1", &x),
+        ];
+        let _ = wls_summary_fit(&inputs).expect("wls_summary_fit failed");
+    }
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("forgetting_factor", 0.99),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let _ = rls_summary_fit(&inputs).expect("rls_summary_fit failed");
+    }
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("lower_bound", -10.0),
+            scalar_f64("upper_bound", 10.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let _ = bls_summary_fit(&inputs).expect("bls_summary_fit failed");
+    }
+
+    // -----------------------------------------------------------------
+    // Linear *_predict_fit variants.
+    // -----------------------------------------------------------------
+    let kwargs = || PredictKwargs {
+        prefix: "p".to_string(),
+    };
+
+    // ols_predict: y, with_intercept, solve_method, interval, level, null_policy, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("x1", &x),
+        ];
+        let out = ols_predict_fit(&inputs, kwargs()).expect("ols_predict_fit failed");
+        assert_eq!(out.len(), y.len(), "predictions length matches input");
+    }
+
+    // ridge_predict: + lambda after null_policy.
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            scalar_f64("lambda", 0.1),
+            series_f64("x1", &x),
+        ];
+        let out = ridge_predict_fit(&inputs, kwargs()).expect("ridge_predict_fit failed");
+        assert_eq!(out.len(), y.len());
+    }
+
+    // elastic_net_predict: + lambda + alpha (no solve_method).
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            scalar_f64("lambda", 0.1),
+            scalar_f64("alpha", 0.5),
+            series_f64("x1", &x),
+        ];
+        let out =
+            elastic_net_predict_fit(&inputs, kwargs()).expect("elastic_net_predict_fit failed");
+        assert_eq!(out.len(), y.len());
+    }
+
+    // wls_predict: + weights at idx 6.
+    {
+        let w = vec![1.0_f64; n];
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("solve_method"),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("weights", &w),
+            series_f64("x1", &x),
+        ];
+        let out = wls_predict_fit(&inputs, kwargs()).expect("wls_predict_fit failed");
+        assert_eq!(out.len(), y.len());
+    }
+
+    // rls_predict.
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            scalar_f64("forgetting_factor", 0.99),
+            series_f64("x1", &x),
+        ];
+        let out = rls_predict_fit(&inputs, kwargs()).expect("rls_predict_fit failed");
+        assert_eq!(out.len(), y.len());
+    }
+
+    // bls_predict: + lower + upper.
+    {
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            scalar_f64("lower_bound", -10.0),
+            scalar_f64("upper_bound", 10.0),
+            series_f64("x1", &x),
+        ];
+        let out = bls_predict_fit(&inputs, kwargs()).expect("bls_predict_fit failed");
+        assert_eq!(out.len(), y.len());
+    }
+}
+
+// =============================================================================
+// GLM family (logistic / poisson / negbin / tweedie / probit / cloglog / alm)
+// + their predict + summary variants
+// =============================================================================
+
+#[test]
+fn glm_fits() {
+    // Binary outcome: y switches at x = 10.
+    let x_bin: Vec<f64> = (0..20).map(|i| i as f64).collect();
+    let y_bin: Vec<f64> = x_bin
+        .iter()
+        .map(|&xi| if xi >= 10.0 { 1.0 } else { 0.0 })
+        .collect();
+
+    // Count outcome: y ~ exp(0.1 * x) rounded.
+    let x_cnt: Vec<f64> = (0..25).map(|i| (i as f64) * 0.1).collect();
+    let y_cnt: Vec<f64> = x_cnt.iter().map(|&xi| (xi * 5.0 + 1.0).round()).collect();
+
+    // Tweedie / continuous positive: small positive.
+    let x_pos: Vec<f64> = (0..25).map(|i| (i as f64) * 0.1 + 0.1).collect();
+    let y_pos: Vec<f64> = x_pos.iter().map(|&xi| 1.0 + 0.5 * xi).collect();
+
+    let kwargs = || PredictKwargs {
+        prefix: "p".to_string(),
+    };
+
+    // logistic_fit: y, lambda, with_intercept, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_bin),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_bin),
+        ];
+        let out = logistic_fit(&inputs).expect("logistic_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        // summary
+        let _ = logistic_summary_fit(&inputs).expect("logistic_summary_fit failed");
+    }
+
+    // poisson_fit: y, lambda, with_intercept, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_cnt),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_cnt),
+        ];
+        let out = poisson_fit(&inputs).expect("poisson_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        let _ = poisson_summary_fit(&inputs).expect("poisson_summary_fit failed");
+    }
+
+    // negative_binomial_fit: y, theta, lambda, with_intercept, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_cnt),
+            scalar_f64("theta", 1.0),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_cnt),
+        ];
+        let out = negative_binomial_fit(&inputs).expect("negative_binomial_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        let _ = negative_binomial_summary_fit(&inputs)
+            .expect("negative_binomial_summary_fit failed");
+    }
+
+    // tweedie_fit: y, var_power, lambda, with_intercept, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_pos),
+            scalar_f64("var_power", 1.5),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_pos),
+        ];
+        let out = tweedie_fit(&inputs).expect("tweedie_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        let _ = tweedie_summary_fit(&inputs).expect("tweedie_summary_fit failed");
+    }
+
+    // probit_fit: y, lambda, with_intercept, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_bin),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_bin),
+        ];
+        let out = probit_fit(&inputs).expect("probit_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        let _ = probit_summary_fit(&inputs).expect("probit_summary_fit failed");
+    }
+
+    // cloglog_fit
+    {
+        let inputs = vec![
+            series_f64("y", &y_bin),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_bin),
+        ];
+        let out = cloglog_fit(&inputs).expect("cloglog_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        let _ = cloglog_summary_fit(&inputs).expect("cloglog_summary_fit failed");
+    }
+
+    // alm_fit: y, distribution, with_intercept, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_pos),
+            scalar_str("distribution", "normal"),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x_pos),
+        ];
+        let out = alm_fit(&inputs).expect("alm_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+        let _ = alm_summary_fit(&inputs).expect("alm_summary_fit failed");
+    }
+
+    // -----------------------------------------------------------------
+    // GLM predict variants
+    // -----------------------------------------------------------------
+
+    // logistic_predict: y, lambda, with_intercept, interval, level, null_policy, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_bin),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("x1", &x_bin),
+        ];
+        let out = logistic_predict_fit(&inputs, kwargs()).expect("logistic_predict_fit failed");
+        assert_eq!(out.len(), y_bin.len());
+    }
+
+    // poisson_predict
+    {
+        let inputs = vec![
+            series_f64("y", &y_cnt),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("x1", &x_cnt),
+        ];
+        let out = poisson_predict_fit(&inputs, kwargs()).expect("poisson_predict_fit failed");
+        assert_eq!(out.len(), y_cnt.len());
+    }
+
+    // negative_binomial_predict
+    {
+        let inputs = vec![
+            series_f64("y", &y_cnt),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("x1", &x_cnt),
+        ];
+        let out = negative_binomial_predict_fit(&inputs, kwargs())
+            .expect("negative_binomial_predict_fit failed");
+        assert_eq!(out.len(), y_cnt.len());
+    }
+
+    // tweedie_predict: y, lambda, with_intercept, interval, level, null_policy, var_power, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_pos),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            scalar_f64("var_power", 1.5),
+            series_f64("x1", &x_pos),
+        ];
+        let out = tweedie_predict_fit(&inputs, kwargs()).expect("tweedie_predict_fit failed");
+        assert_eq!(out.len(), y_pos.len());
+    }
+
+    // probit_predict
+    {
+        let inputs = vec![
+            series_f64("y", &y_bin),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("x1", &x_bin),
+        ];
+        let out = probit_predict_fit(&inputs, kwargs()).expect("probit_predict_fit failed");
+        assert_eq!(out.len(), y_bin.len());
+    }
+
+    // cloglog_predict
+    {
+        let inputs = vec![
+            series_f64("y", &y_bin),
+            scalar_f64("lambda", 0.0),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            series_f64("x1", &x_bin),
+        ];
+        let out = cloglog_predict_fit(&inputs, kwargs()).expect("cloglog_predict_fit failed");
+        assert_eq!(out.len(), y_bin.len());
+    }
+
+    // alm_predict: y, with_intercept, interval, level, null_policy, distribution, x...
+    {
+        let inputs = vec![
+            series_f64("y", &y_pos),
+            scalar_bool("with_intercept", true),
+            scalar_str_null("interval"),
+            scalar_f64("level", 0.95),
+            scalar_str("null_policy", "drop"),
+            scalar_str("distribution", "normal"),
+            series_f64("x1", &x_pos),
+        ];
+        let out = alm_predict_fit(&inputs, kwargs()).expect("alm_predict_fit failed");
+        assert_eq!(out.len(), y_pos.len());
+    }
+}
+
+// =============================================================================
+// Diagnostics (condition_number / check_binary_separation / check_count_sparsity)
+// =============================================================================
+
+#[test]
+fn diagnostic_fits() {
+    // condition_number_fit: inputs[0] = with_intercept, inputs[1..] = x columns.
+    let x1: Vec<f64> = (0..20).map(|i| i as f64).collect();
+    let x2: Vec<f64> = (0..20).map(|i| (i as f64) * 0.5 + 1.0).collect();
+    {
+        let inputs = vec![
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let out = condition_number_fit(&inputs).expect("condition_number_fit failed");
+        // Severity field should be present.
+        let st = out.struct_().unwrap();
+        let _sev = st.field_by_name("severity").unwrap();
+    }
+
+    // check_binary_separation_fit: y (binary), x columns.
+    {
+        let y: Vec<f64> = (0..20)
+            .map(|i| if i >= 10 { 1.0 } else { 0.0 })
+            .collect();
+        let inputs = vec![
+            series_f64("y", &y),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let out =
+            check_binary_separation_fit(&inputs).expect("check_binary_separation_fit failed");
+        let st = out.struct_().unwrap();
+        let _has = st.field_by_name("has_separation").unwrap();
+    }
+
+    // check_count_sparsity_fit: y (counts), x columns.
+    {
+        let y: Vec<f64> = (0..20).map(|i| (i % 5) as f64).collect();
+        let inputs = vec![
+            series_f64("y", &y),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let out = check_count_sparsity_fit(&inputs).expect("check_count_sparsity_fit failed");
+        let st = out.struct_().unwrap();
+        let _has = st.field_by_name("has_separation").unwrap();
+    }
+}
+
+// =============================================================================
+// Parametric tests (t-test ind/paired, Brown-Forsythe, Yuen)
+// =============================================================================
+
+#[test]
+fn parametric_tests() {
+    let (a, b) = two_samples();
+
+    // ttest_ind_fit: x, y, alternative, equal_var, mu, conf_level
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("alternative", "two-sided"),
+            scalar_bool("equal_var", false),
+            scalar_f64("mu", 0.0),
+            scalar_f64("conf_level", 0.95),
+        ];
+        let out = ttest_ind_fit(&inputs).expect("ttest_ind_fit failed");
+        let st = out.struct_().unwrap();
+        let _stat = st.field_by_name("statistic").unwrap();
+    }
+
+    // ttest_paired_fit: x, y, alternative, mu, conf_level
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("alternative", "two-sided"),
+            scalar_f64("mu", 0.0),
+            scalar_f64("conf_level", 0.95),
+        ];
+        let _ = ttest_paired_fit(&inputs).expect("ttest_paired_fit failed");
+    }
+
+    // brown_forsythe_fit: two groups.
+    {
+        let inputs = vec![series_f64("x", &a), series_f64("y", &b)];
+        let _ = brown_forsythe_fit(&inputs).expect("brown_forsythe_fit failed");
+    }
+
+    // yuen_test_fit: x, y, trim, alternative, conf_level
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_f64("trim", 0.2),
+            scalar_str("alternative", "two-sided"),
+            scalar_f64("conf_level", 0.95),
+        ];
+        let _ = yuen_test_fit(&inputs).expect("yuen_test_fit failed");
+    }
+}
+
+// =============================================================================
+// Non-parametric tests
+// =============================================================================
+
+#[test]
+fn nonparametric_tests() {
+    let (a, b) = two_samples();
+
+    // mann_whitney_u_fit: x, y, alternative, continuity_correction, exact, conf_level, mu
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("alternative", "two-sided"),
+            scalar_bool("continuity_correction", true),
+            scalar_bool("exact", false),
+            scalar_f64("conf_level", 0.95),
+            scalar_f64("mu", 0.0),
+        ];
+        let _ = mann_whitney_u_fit(&inputs).expect("mann_whitney_u_fit failed");
+    }
+
+    // wilcoxon_signed_rank_fit: x, y, alternative, continuity_correction, exact, conf_level, mu
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("alternative", "two-sided"),
+            scalar_bool("continuity_correction", true),
+            scalar_bool("exact", false),
+            scalar_f64("conf_level", 0.95),
+            scalar_f64("mu", 0.0),
+        ];
+        let _ = wilcoxon_signed_rank_fit(&inputs).expect("wilcoxon_signed_rank_fit failed");
+    }
+
+    // kruskal_wallis_fit: each input series is a separate group.
+    {
+        let c: Vec<f64> = (0..25).map(|i| (i as f64) * 0.5 + 2.0).collect();
+        let inputs = vec![
+            series_f64("g1", &a),
+            series_f64("g2", &b),
+            series_f64("g3", &c),
+        ];
+        let _ = kruskal_wallis_fit(&inputs).expect("kruskal_wallis_fit failed");
+    }
+
+    // brunner_munzel_fit: x, y, alternative, alpha
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("alternative", "two-sided"),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = brunner_munzel_fit(&inputs).expect("brunner_munzel_fit failed");
+    }
+}
+
+// =============================================================================
+// Distributional tests (normality)
+// =============================================================================
+
+#[test]
+fn distributional_tests() {
+    // shapiro_wilk_fit: x only.
+    let x: Vec<f64> = (0..30)
+        .map(|i| (i as f64) * 0.3 + 0.7 * ((i as f64).sin()))
+        .collect();
+    {
+        let inputs = vec![series_f64("x", &x)];
+        let _ = shapiro_wilk_fit(&inputs).expect("shapiro_wilk_fit failed");
+    }
+    // dagostino_fit (D'Agostino K-squared): x only.
+    {
+        let inputs = vec![series_f64("x", &x)];
+        let _ = dagostino_fit(&inputs).expect("dagostino_fit failed");
+    }
+}
+
+// =============================================================================
+// Correlation tests
+// =============================================================================
+
+#[test]
+fn correlation_fits() {
+    let (a, b) = two_samples();
+
+    // pearson_fit: x, y, conf_level
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_f64("conf_level", 0.95),
+        ];
+        let out = pearson_fit(&inputs).expect("pearson_fit failed");
+        assert_n_obs_nonzero(&out, "n");
+    }
+
+    // spearman_fit: x, y, conf_level
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_f64("conf_level", 0.95),
+        ];
+        let out = spearman_fit(&inputs).expect("spearman_fit failed");
+        assert_n_obs_nonzero(&out, "n");
+    }
+
+    // kendall_fit: x, y, variant (str)
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("variant", "b"),
+        ];
+        let _ = kendall_fit(&inputs).expect("kendall_fit failed");
+    }
+
+    // distance_cor_fit: x, y, n_permutations, seed
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_u32("n_permutations", 99),
+            scalar_u64_null("seed"),
+        ];
+        let _ = distance_cor_fit(&inputs).expect("distance_cor_fit failed");
+    }
+
+    // partial_cor_fit: x, y, n_covariates (u32), then n_covariates covariates.
+    {
+        let cov: Vec<f64> = (0..25).map(|i| (i as f64) * 0.2).collect();
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_u32("n_covariates", 1),
+            series_f64("cov1", &cov),
+        ];
+        let _ = partial_cor_fit(&inputs).expect("partial_cor_fit failed");
+    }
+
+    // semi_partial_cor_fit: same layout as partial_cor_fit.
+    {
+        let cov: Vec<f64> = (0..25).map(|i| (i as f64) * 0.2).collect();
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_u32("n_covariates", 1),
+            series_f64("cov1", &cov),
+        ];
+        let _ = semi_partial_cor_fit(&inputs).expect("semi_partial_cor_fit failed");
+    }
+
+    // icc_fit: values, icc_type, conf_level. This is currently a placeholder
+    // implementation in the crate (returns NaNs) but must still be reachable.
+    {
+        let vals: Vec<f64> = (0..30).map(|i| i as f64).collect();
+        let inputs = vec![
+            series_f64("values", &vals),
+            scalar_str("icc_type", "icc1"),
+            scalar_f64("conf_level", 0.95),
+        ];
+        let _ = icc_fit(&inputs).expect("icc_fit failed");
+    }
+}
+
+// =============================================================================
+// Categorical / contingency-table tests
+// =============================================================================
+
+#[test]
+fn categorical_fits() {
+    // binom_test_fit: successes (u32), n (u32), p0 (f64), alternative (str)
+    {
+        let inputs = vec![
+            scalar_u32("successes", 7),
+            scalar_u32("n", 10),
+            scalar_f64("p0", 0.5),
+            scalar_str("alternative", "two-sided"),
+        ];
+        let _ = binom_test_fit(&inputs).expect("binom_test_fit failed");
+    }
+
+    // prop_test_one_fit
+    {
+        let inputs = vec![
+            scalar_u32("successes", 30),
+            scalar_u32("n", 100),
+            scalar_f64("p0", 0.4),
+            scalar_str("alternative", "two-sided"),
+        ];
+        let _ = prop_test_one_fit(&inputs).expect("prop_test_one_fit failed");
+    }
+
+    // prop_test_two_fit
+    {
+        let inputs = vec![
+            scalar_u32("s1", 30),
+            scalar_u32("n1", 100),
+            scalar_u32("s2", 25),
+            scalar_u32("n2", 100),
+            scalar_str("alternative", "two-sided"),
+            scalar_bool("correction", false),
+        ];
+        let _ = prop_test_two_fit(&inputs).expect("prop_test_two_fit failed");
+    }
+
+    // chisq_test_fit: 2x2 flattened table (u32 series of length 4), n_rows, n_cols, correction.
+    {
+        let table = Series::new("table".into(), &[10u32, 20, 30, 40]);
+        let inputs = vec![
+            table,
+            scalar_u32("n_rows", 2),
+            scalar_u32("n_cols", 2),
+            scalar_bool("correction", false),
+        ];
+        let _ = chisq_test_fit(&inputs).expect("chisq_test_fit failed");
+    }
+
+    // chisq_goodness_of_fit_fit: observed (u32), has_expected (bool); no expected.
+    {
+        let observed = Series::new("observed".into(), &[15u32, 25, 30, 20]);
+        let inputs = vec![observed, scalar_bool("has_expected", false)];
+        let _ = chisq_goodness_of_fit_fit(&inputs).expect("chisq_goodness_of_fit_fit failed");
+    }
+
+    // g_test_fit: same shape as chisq_test_fit (without correction).
+    {
+        let table = Series::new("table".into(), &[10u32, 20, 30, 40]);
+        let inputs = vec![table, scalar_u32("n_rows", 2), scalar_u32("n_cols", 2)];
+        let _ = g_test_fit(&inputs).expect("g_test_fit failed");
+    }
+
+    // fisher_exact_fit: a, b, c, d, alternative
+    {
+        let inputs = vec![
+            scalar_u32("a", 8),
+            scalar_u32("b", 2),
+            scalar_u32("c", 1),
+            scalar_u32("d", 5),
+            scalar_str("alternative", "two-sided"),
+        ];
+        let _ = fisher_exact_fit(&inputs).expect("fisher_exact_fit failed");
+    }
+
+    // mcnemar_test_fit: a, b, c, d, correction
+    {
+        let inputs = vec![
+            scalar_u32("a", 30),
+            scalar_u32("b", 12),
+            scalar_u32("c", 5),
+            scalar_u32("d", 50),
+            scalar_bool("correction", false),
+        ];
+        let _ = mcnemar_test_fit(&inputs).expect("mcnemar_test_fit failed");
+    }
+
+    // mcnemar_exact_fit: a, b, c, d
+    {
+        let inputs = vec![
+            scalar_u32("a", 30),
+            scalar_u32("b", 12),
+            scalar_u32("c", 5),
+            scalar_u32("d", 50),
+        ];
+        let _ = mcnemar_exact_fit(&inputs).expect("mcnemar_exact_fit failed");
+    }
+
+    // cohen_kappa_fit: matrix flattened (u32), n_categories, weighted
+    {
+        // 2x2 confusion matrix
+        let matrix = Series::new("matrix".into(), &[20u32, 5, 10, 30]);
+        let inputs = vec![
+            matrix,
+            scalar_u32("n_categories", 2),
+            scalar_bool("weighted", false),
+        ];
+        let _ = cohen_kappa_fit(&inputs).expect("cohen_kappa_fit failed");
+    }
+
+    // cramers_v_fit: flattened table, n_rows, n_cols
+    {
+        let table = Series::new("table".into(), &[10u32, 20, 30, 40]);
+        let inputs = vec![table, scalar_u32("n_rows", 2), scalar_u32("n_cols", 2)];
+        let _ = cramers_v_fit(&inputs).expect("cramers_v_fit failed");
+    }
+
+    // phi_coefficient_fit: a, b, c, d (2x2)
+    {
+        let inputs = vec![
+            scalar_u32("a", 10),
+            scalar_u32("b", 20),
+            scalar_u32("c", 30),
+            scalar_u32("d", 40),
+        ];
+        let _ = phi_coefficient_fit(&inputs).expect("phi_coefficient_fit failed");
+    }
+
+    // contingency_coef_fit: flattened table, n_rows, n_cols
+    {
+        let table = Series::new("table".into(), &[10u32, 20, 30, 40]);
+        let inputs = vec![table, scalar_u32("n_rows", 2), scalar_u32("n_cols", 2)];
+        let _ = contingency_coef_fit(&inputs).expect("contingency_coef_fit failed");
+    }
+}
+
+// =============================================================================
+// Forecast comparison tests
+// =============================================================================
+
+#[test]
+fn forecast_fits() {
+    // Two error series of length 50.
+    let e1: Vec<f64> = (0..50)
+        .map(|i| (i as f64).sin() * 0.5 + 0.1)
+        .collect();
+    let e2: Vec<f64> = (0..50)
+        .map(|i| (i as f64).cos() * 0.5 + 0.15)
+        .collect();
+    let e3: Vec<f64> = (0..50)
+        .map(|i| ((i as f64) * 0.7).sin() * 0.4 + 0.2)
+        .collect();
+
+    // diebold_mariano_fit: e1, e2, loss (str), h (u32), alt (str), var_est (str)
+    {
+        let inputs = vec![
+            series_f64("e1", &e1),
+            series_f64("e2", &e2),
+            scalar_str("loss", "squared"),
+            scalar_u32("h", 1),
+            scalar_str("alternative", "two-sided"),
+            scalar_str("var_est", "acf"),
+        ];
+        let _ = diebold_mariano_fit(&inputs).expect("diebold_mariano_fit failed");
+    }
+
+    // permutation_t_test_fit: x, y, alternative, n_perm (u32), seed (u64 nullable)
+    {
+        let inputs = vec![
+            series_f64("x", &e1),
+            series_f64("y", &e2),
+            scalar_str("alternative", "two-sided"),
+            scalar_u32("n_perm", 99),
+            scalar_u64("seed", 42),
+        ];
+        let _ = permutation_t_test_fit(&inputs).expect("permutation_t_test_fit failed");
+    }
+
+    // clark_west_fit: e1, e2, h
+    {
+        let inputs = vec![
+            series_f64("e1", &e1),
+            series_f64("e2", &e2),
+            scalar_u32("h", 1),
+        ];
+        let _ = clark_west_fit(&inputs).expect("clark_west_fit failed");
+    }
+
+    // spa_test_fit: benchmark, n_bootstrap, block_length, seed, then model losses.
+    {
+        let inputs = vec![
+            series_f64("benchmark", &e1),
+            scalar_u32("n_bootstrap", 99),
+            scalar_f64("block_length", 5.0),
+            scalar_u64("seed", 42),
+            series_f64("m1", &e2),
+            series_f64("m2", &e3),
+        ];
+        let _ = spa_test_fit(&inputs).expect("spa_test_fit failed");
+    }
+
+    // model_confidence_set_fit: alpha, stat (str), n_bootstrap, block_length, seed, then model losses.
+    {
+        let inputs = vec![
+            scalar_f64("alpha", 0.1),
+            scalar_str("stat", "range"),
+            scalar_u32("n_bootstrap", 99),
+            scalar_f64("block_length", 5.0),
+            scalar_u64("seed", 42),
+            series_f64("m1", &e1),
+            series_f64("m2", &e2),
+            series_f64("m3", &e3),
+        ];
+        let _ = model_confidence_set_fit(&inputs).expect("model_confidence_set_fit failed");
+    }
+
+    // mspe_adjusted_fit: benchmark, n_bootstrap, block_length, seed, then model errors.
+    {
+        let inputs = vec![
+            series_f64("benchmark", &e1),
+            scalar_u32("n_bootstrap", 99),
+            scalar_f64("block_length", 5.0),
+            scalar_u64("seed", 42),
+            series_f64("m1", &e2),
+        ];
+        let _ = mspe_adjusted_fit(&inputs).expect("mspe_adjusted_fit failed");
+    }
+}
+
+// =============================================================================
+// Modern tests (Energy Distance, MMD)
+// =============================================================================
+
+#[test]
+fn modern_fits() {
+    let (a, b) = two_samples();
+
+    // energy_distance_fit: x, y, n_perm, seed
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_u32("n_perm", 99),
+            scalar_u64("seed", 42),
+        ];
+        let _ = energy_distance_fit(&inputs).expect("energy_distance_fit failed");
+    }
+
+    // mmd_test_fit: x, y, n_perm, seed
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_u32("n_perm", 99),
+            scalar_u64("seed", 42),
+        ];
+        let _ = mmd_test_fit(&inputs).expect("mmd_test_fit failed");
+    }
+}
+
+// =============================================================================
+// TOST equivalence tests
+// =============================================================================
+
+#[test]
+fn tost_fits() {
+    let (a, b) = two_samples();
+
+    // tost_t_test_one_sample_fit: x, mu, bounds_type, delta, lower, upper, alpha
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            scalar_f64("mu", 0.0),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_t_test_one_sample_fit(&inputs).expect("tost_t_test_one_sample_fit failed");
+    }
+
+    // tost_t_test_two_sample_fit: x, y, bounds_type, delta, lower, upper, alpha, pooled
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+            scalar_bool("pooled", false),
+        ];
+        let _ = tost_t_test_two_sample_fit(&inputs).expect("tost_t_test_two_sample_fit failed");
+    }
+
+    // tost_t_test_paired_fit
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_t_test_paired_fit(&inputs).expect("tost_t_test_paired_fit failed");
+    }
+
+    // tost_correlation_fit: x, y, method, rho_null, bounds_type, delta, lower, upper, alpha
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("method", "pearson"),
+            scalar_f64("rho_null", 0.0),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 0.3),
+            scalar_f64("lower", -0.3),
+            scalar_f64("upper", 0.3),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_correlation_fit(&inputs).expect("tost_correlation_fit failed");
+    }
+
+    // tost_prop_one_fit: successes, n, p0, bounds_type, delta, lower, upper, alpha
+    {
+        let inputs = vec![
+            scalar_u32("successes", 50),
+            scalar_u32("n", 100),
+            scalar_f64("p0", 0.5),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 0.1),
+            scalar_f64("lower", -0.1),
+            scalar_f64("upper", 0.1),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_prop_one_fit(&inputs).expect("tost_prop_one_fit failed");
+    }
+
+    // tost_prop_two_fit
+    {
+        let inputs = vec![
+            scalar_u32("s1", 48),
+            scalar_u32("n1", 100),
+            scalar_u32("s2", 52),
+            scalar_u32("n2", 100),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 0.1),
+            scalar_f64("lower", -0.1),
+            scalar_f64("upper", 0.1),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_prop_two_fit(&inputs).expect("tost_prop_two_fit failed");
+    }
+
+    // tost_wilcoxon_paired_fit
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_wilcoxon_paired_fit(&inputs).expect("tost_wilcoxon_paired_fit failed");
+    }
+
+    // tost_wilcoxon_two_sample_fit
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ =
+            tost_wilcoxon_two_sample_fit(&inputs).expect("tost_wilcoxon_two_sample_fit failed");
+    }
+
+    // tost_bootstrap_fit: x, y, bounds_type, delta, lower, upper, alpha, n_bootstrap, seed
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+            scalar_u32("n_bootstrap", 99),
+            scalar_u64("seed", 42),
+        ];
+        let _ = tost_bootstrap_fit(&inputs).expect("tost_bootstrap_fit failed");
+    }
+
+    // tost_yuen_fit: x, y, trim, bounds_type, delta, lower, upper, alpha
+    {
+        let inputs = vec![
+            series_f64("x", &a),
+            series_f64("y", &b),
+            scalar_f64("trim", 0.2),
+            scalar_str("bounds_type", "symmetric"),
+            scalar_f64("delta", 5.0),
+            scalar_f64("lower", -5.0),
+            scalar_f64("upper", 5.0),
+            scalar_f64("alpha", 0.05),
+        ];
+        let _ = tost_yuen_fit(&inputs).expect("tost_yuen_fit failed");
+    }
+}
+
+// =============================================================================
+// Dynamic / AID models (lm_dynamic_fit, aid_fit, aid_anomalies_fit)
+// =============================================================================
+
+#[test]
+fn dynamic_model_fits() {
+    // aid_fit: y, intermittent_threshold (f64), detect_anomalies (bool)
+    {
+        // Intermittent count series with occasional zeros.
+        let y: Vec<f64> = (0..30)
+            .map(|i| if i % 3 == 0 { 0.0 } else { (i as f64) % 5.0 + 1.0 })
+            .collect();
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("intermittent_threshold", 0.3),
+            scalar_bool("detect_anomalies", true),
+        ];
+        let out = aid_fit(&inputs).expect("aid_fit failed");
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // aid_anomalies_fit: y, intermittent_threshold
+    {
+        let y: Vec<f64> = (0..30)
+            .map(|i| if i % 3 == 0 { 0.0 } else { (i as f64) % 5.0 + 1.0 })
+            .collect();
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_f64("intermittent_threshold", 0.3),
+        ];
+        let out = aid_anomalies_fit(&inputs).expect("aid_anomalies_fit failed");
+        // n rows of per-observation anomaly flags.
+        assert_eq!(out.len(), y.len());
+    }
+
+    // lm_dynamic_fit: y, ic (str), distribution (str), lowess_span (f64),
+    //                 max_models (u32), with_intercept (bool), x columns
+    {
+        let (x, y) = linear_xy();
+        let inputs = vec![
+            series_f64("y", &y),
+            scalar_str("ic", "aicc"),
+            scalar_str("distribution", "normal"),
+            scalar_f64("lowess_span", 0.0), // disable smoothing for stability
+            scalar_u32("max_models", 16),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x),
+        ];
+        let out = lm_dynamic_fit(&inputs).expect("lm_dynamic_fit failed");
+        // n_observations field non-zero.
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+}
+
+// =============================================================================
+// Tail helper to silence unused-warning when assert_f64_finite_or_zero is
+// not used in some configurations.
+// =============================================================================
+
+#[allow(dead_code)]
+fn _touch_unused() {
+    let s = Series::new("x".into(), &[1.0_f64]);
+    assert_f64_finite_or_zero(&s, "x");
+}


### PR DESCRIPTION
Closes #13.

## Summary

`polars-statistics` is now a hybrid crate: the same source produces both the Python wheel (`cdylib`) and an `rlib` that downstream Rust crates can depend on directly. Two known consumers — `kaercher-forecast` and the `anofox-orchestration` metalearner — can now share the Polars↔`anofox-regression` boundary in-process, with no Python round-trip.

- `crate-type = ["cdylib", "rlib"]`, lib renamed `polars_statistics`
- New `python` feature (default on) gates `pyo3` / `numpy` / `pymodels` / `utils`. `pyo3-polars` stays available for the `polars_expr` macro in either mode.
- Every `#[polars_expr] fn pl_X` is split into:
  - a thin shim that the macro wraps for the Polars FFI plugin path, and
  - a `pub fn X_fit(inputs) -> PolarsResult<Series>` sibling that holds the body and is callable directly from Rust.
- This is a workaround for the `polars_expr` macro relocating the original fn body into its `extern "C"` wrapper (making `pub fn pl_X` invisible at module scope, confirmed via `cargo expand`).
- **95 `*_fit` functions** are now reachable via `polars_statistics::expressions`.
- `examples/rust_wls.rs` demonstrates per-(site) WLS via `partition_by`.
- `tests/rust_api.rs` (1452 lines) exercises every `*_fit` — deep assertions for `ols_fit` / `wls_fit` / `ridge_fit` / `quantile_fit`, smoke tests for the remaining 91.
- Crate bumps: `anofox-regression` 0.5.2 → 0.5.4, `anofox-statistics` 0.4.0 → 0.4.1.
- README: new "Use from Rust" section.

## Acceptance criteria (from #13)

- [x] `cargo build --no-default-features` produces an rlib with no pyo3 link
- [x] `pip install` and the existing Python API are unchanged (366/366 pytest)
- [x] A minimal Rust example fits a WLS model via Polars expressions over a `group_by`
- [x] No behavioural change in the existing Python-side expressions

## Test plan

- [x] `cargo build --no-default-features` — rlib builds clean, no `Py_*` libpython symbols
- [x] `cargo build` — default `python` feature, cdylib builds clean
- [x] `cargo run --example rust_wls --no-default-features` — prints expected per-site fits (A: y=1+2x, B: y=2+3x, R²=1.0)
- [x] `cargo test --no-default-features` — 12/12 pass
- [x] `pytest` — 366/366 pass
- [ ] `maturin build` (CI) — should be unchanged

## Coverage audit follow-ups

The audit against `anofox-regression 0.5.4` surfaced wrapping gaps unrelated to #13's scope. Filed as separate issues:

- #14 — Wrap 0.5.4 solvers: `HuberRegressor` and sklearn-style `LogisticRegression`
- #15 — Expose penalized IRLS `lambda` kwarg on all GLM wrappers
- #16 — Bring `pl_alm` to parity with `PyALM` (distributions, loss, link)
- #17 — Wrap diagnostics toolkit (VIF, leverage, Cook's, residuals)
- #18 — Add `_summary` / `_predict` expressions for Quantile, Isotonic, LmDynamic, Aid
- #19 — Wrap `PlsRegressor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)