### PR TITLE
Expose penalized IRLS lambda_ on GLM PyClass models

### DIFF
--- a/src/pymodels/py_cloglog.rs
+++ b/src/pymodels/py_cloglog.rs
@@ -27,18 +27,20 @@ pub struct PyCloglog {
     with_intercept: bool,
     max_iter: usize,
     tol: f64,
+    lambda_: f64,
     fitted: Option<FittedBinomial>,
 }
 
 #[pymethods]
 impl PyCloglog {
     #[new]
-    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6))]
-    fn new(with_intercept: bool, max_iter: usize, tol: f64) -> Self {
+    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
+    fn new(with_intercept: bool, max_iter: usize, tol: f64, lambda_: f64) -> Self {
         Self {
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
@@ -55,6 +57,7 @@ impl PyCloglog {
             .with_intercept(slf.with_intercept)
             .max_iterations(slf.max_iter)
             .tolerance(slf.tol)
+            .lambda(slf.lambda_)
             .build();
 
         let fitted = model

--- a/src/pymodels/py_logistic.rs
+++ b/src/pymodels/py_logistic.rs
@@ -30,19 +30,21 @@ pub struct PyLogistic {
     confidence_level: f64,
     max_iter: usize,
     tol: f64,
+    lambda_: f64,
     fitted: Option<FittedBinomial>,
 }
 
 #[pymethods]
 impl PyLogistic {
     #[new]
-    #[pyo3(signature = (with_intercept=true, compute_inference=true, confidence_level=0.95, max_iter=25, tol=1e-8))]
+    #[pyo3(signature = (with_intercept=true, compute_inference=true, confidence_level=0.95, max_iter=25, tol=1e-8, lambda_=0.0))]
     fn new(
         with_intercept: bool,
         compute_inference: bool,
         confidence_level: f64,
         max_iter: usize,
         tol: f64,
+        lambda_: f64,
     ) -> Self {
         Self {
             with_intercept,
@@ -50,6 +52,7 @@ impl PyLogistic {
             confidence_level,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
@@ -76,6 +79,7 @@ impl PyLogistic {
             .confidence_level(slf.confidence_level)
             .max_iterations(slf.max_iter)
             .tolerance(slf.tol)
+            .lambda(slf.lambda_)
             .build();
 
         let fitted = model

--- a/src/pymodels/py_negative_binomial.rs
+++ b/src/pymodels/py_negative_binomial.rs
@@ -33,19 +33,21 @@ pub struct PyNegativeBinomial {
     with_intercept: bool,
     max_iter: usize,
     tol: f64,
+    lambda_: f64,
     fitted: Option<FittedNegativeBinomial>,
 }
 
 #[pymethods]
 impl PyNegativeBinomial {
     #[new]
-    #[pyo3(signature = (theta=None, estimate_theta=true, with_intercept=true, max_iter=100, tol=1e-6))]
+    #[pyo3(signature = (theta=None, estimate_theta=true, with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
     fn new(
         theta: Option<f64>,
         estimate_theta: bool,
         with_intercept: bool,
         max_iter: usize,
         tol: f64,
+        lambda_: f64,
     ) -> Self {
         Self {
             theta,
@@ -53,6 +55,7 @@ impl PyNegativeBinomial {
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
@@ -69,7 +72,8 @@ impl PyNegativeBinomial {
             .with_intercept(slf.with_intercept)
             .estimate_theta(slf.estimate_theta)
             .max_iterations(slf.max_iter)
-            .tolerance(slf.tol);
+            .tolerance(slf.tol)
+            .lambda(slf.lambda_);
 
         if let Some(theta) = slf.theta {
             builder = builder.theta(theta);

--- a/src/pymodels/py_poisson.rs
+++ b/src/pymodels/py_poisson.rs
@@ -30,19 +30,21 @@ pub struct PyPoisson {
     confidence_level: f64,
     max_iter: usize,
     tol: f64,
+    lambda_: f64,
     fitted: Option<FittedPoisson>,
 }
 
 #[pymethods]
 impl PyPoisson {
     #[new]
-    #[pyo3(signature = (with_intercept=true, compute_inference=true, confidence_level=0.95, max_iter=25, tol=1e-8))]
+    #[pyo3(signature = (with_intercept=true, compute_inference=true, confidence_level=0.95, max_iter=25, tol=1e-8, lambda_=0.0))]
     fn new(
         with_intercept: bool,
         compute_inference: bool,
         confidence_level: f64,
         max_iter: usize,
         tol: f64,
+        lambda_: f64,
     ) -> Self {
         Self {
             with_intercept,
@@ -50,6 +52,7 @@ impl PyPoisson {
             confidence_level,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
@@ -76,6 +79,7 @@ impl PyPoisson {
             .confidence_level(slf.confidence_level)
             .max_iterations(slf.max_iter)
             .tolerance(slf.tol)
+            .lambda(slf.lambda_)
             .build();
 
         let fitted = model

--- a/src/pymodels/py_probit.rs
+++ b/src/pymodels/py_probit.rs
@@ -28,18 +28,20 @@ pub struct PyProbit {
     with_intercept: bool,
     max_iter: usize,
     tol: f64,
+    lambda_: f64,
     fitted: Option<FittedBinomial>,
 }
 
 #[pymethods]
 impl PyProbit {
     #[new]
-    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6))]
-    fn new(with_intercept: bool, max_iter: usize, tol: f64) -> Self {
+    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
+    fn new(with_intercept: bool, max_iter: usize, tol: f64, lambda_: f64) -> Self {
         Self {
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
@@ -56,6 +58,7 @@ impl PyProbit {
             .with_intercept(slf.with_intercept)
             .max_iterations(slf.max_iter)
             .tolerance(slf.tol)
+            .lambda(slf.lambda_)
             .build();
 
         let fitted = model

--- a/src/pymodels/py_tweedie.rs
+++ b/src/pymodels/py_tweedie.rs
@@ -40,19 +40,21 @@ pub struct PyTweedie {
     with_intercept: bool,
     max_iter: usize,
     tol: f64,
+    lambda_: f64,
     fitted: Option<FittedTweedie>,
 }
 
 #[pymethods]
 impl PyTweedie {
     #[new]
-    #[pyo3(signature = (var_power=1.5, link_power=None, with_intercept=true, max_iter=100, tol=1e-6))]
+    #[pyo3(signature = (var_power=1.5, link_power=None, with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
     fn new(
         var_power: f64,
         link_power: Option<f64>,
         with_intercept: bool,
         max_iter: usize,
         tol: f64,
+        lambda_: f64,
     ) -> Self {
         Self {
             var_power,
@@ -60,48 +62,52 @@ impl PyTweedie {
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
 
     /// Create a Gaussian (Normal) Tweedie model (var_power=0).
     #[staticmethod]
-    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6))]
-    fn gaussian(with_intercept: bool, max_iter: usize, tol: f64) -> Self {
+    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
+    fn gaussian(with_intercept: bool, max_iter: usize, tol: f64, lambda_: f64) -> Self {
         Self {
             var_power: 0.0,
             link_power: Some(1.0),
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
 
     /// Create a Gamma Tweedie model (var_power=2).
     #[staticmethod]
-    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6))]
-    fn gamma(with_intercept: bool, max_iter: usize, tol: f64) -> Self {
+    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
+    fn gamma(with_intercept: bool, max_iter: usize, tol: f64, lambda_: f64) -> Self {
         Self {
             var_power: 2.0,
             link_power: Some(0.0),
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
 
     /// Create an Inverse Gaussian Tweedie model (var_power=3).
     #[staticmethod]
-    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6))]
-    fn inverse_gaussian(with_intercept: bool, max_iter: usize, tol: f64) -> Self {
+    #[pyo3(signature = (with_intercept=true, max_iter=100, tol=1e-6, lambda_=0.0))]
+    fn inverse_gaussian(with_intercept: bool, max_iter: usize, tol: f64, lambda_: f64) -> Self {
         Self {
             var_power: 3.0,
             link_power: Some(0.0),
             with_intercept,
             max_iter,
             tol,
+            lambda_,
             fitted: None,
         }
     }
@@ -118,7 +124,8 @@ impl PyTweedie {
             .var_power(slf.var_power)
             .with_intercept(slf.with_intercept)
             .max_iterations(slf.max_iter)
-            .tolerance(slf.tol);
+            .tolerance(slf.tol)
+            .lambda(slf.lambda_);
 
         if let Some(lp) = slf.link_power {
             builder = builder.link_power(lp);

--- a/tests/test_glm_lambda.py
+++ b/tests/test_glm_lambda.py
@@ -1,0 +1,137 @@
+"""Tests for the `lambda_` (penalized IRLS) kwarg on GLM PyClasses (issue #15)."""
+
+import numpy as np
+import pytest
+
+from polars_statistics import (
+    Cloglog,
+    Logistic,
+    NegativeBinomial,
+    Poisson,
+    Probit,
+    Tweedie,
+)
+
+
+@pytest.fixture
+def logistic_data():
+    """Modest-signal binary outcome — pattern that converges quickly."""
+    np.random.seed(42)
+    n = 200
+    x = np.random.randn(n, 2)
+    y = ((x[:, 0] + x[:, 1] + np.random.randn(n) * 0.5) > 0).astype(float)
+    return x, y
+
+
+@pytest.fixture
+def count_data():
+    """Modest-signal Poisson counts that converge quickly."""
+    np.random.seed(43)
+    n = 200
+    x = np.random.randn(n, 2) * 0.5
+    y = np.random.poisson(np.exp(x[:, 0] * 0.3 + 0.5)).astype(float)
+    return x, y
+
+
+def _coef_norm(model):
+    return float(np.linalg.norm(model.coefficients))
+
+
+class TestLambdaShrinks:
+    """For each GLM, lambda_ > 0 should shrink coefficient L2 norm vs lambda_ = 0."""
+
+    def test_logistic(self, logistic_data):
+        x, y = logistic_data
+        unreg = Logistic(max_iter=100).fit(x, y)
+        strong = Logistic(max_iter=100, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+    def test_poisson(self, count_data):
+        x, y = count_data
+        unreg = Poisson(max_iter=100).fit(x, y)
+        strong = Poisson(max_iter=100, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+    def test_probit(self, logistic_data):
+        x, y = logistic_data
+        unreg = Probit(max_iter=200).fit(x, y)
+        strong = Probit(max_iter=200, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+    def test_cloglog(self, logistic_data):
+        x, y = logistic_data
+        unreg = Cloglog(max_iter=200).fit(x, y)
+        strong = Cloglog(max_iter=200, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+    def test_negative_binomial(self, count_data):
+        x, y = count_data
+        # estimate_theta=False keeps the fit deterministic for the shrinkage check
+        unreg = NegativeBinomial(
+            theta=1.0, estimate_theta=False, max_iter=200
+        ).fit(x, y)
+        strong = NegativeBinomial(
+            theta=1.0, estimate_theta=False, max_iter=200, lambda_=1.0
+        ).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+    def test_tweedie(self):
+        # Use the same data shape as test_models.py's Tweedie tests so the
+        # unreg fit converges; we only need shrinkage between two lambda values.
+        np.random.seed(44)
+        n = 200
+        x = np.random.randn(n, 2) * 0.3
+        y = np.exp(0.5 + 0.3 * x[:, 0] - 0.2 * x[:, 1]) + np.abs(
+            np.random.randn(n) * 0.1
+        )
+        unreg = Tweedie(var_power=1.5, max_iter=200).fit(x, y)
+        strong = Tweedie(var_power=1.5, max_iter=200, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+
+class TestLambdaDefaultIsZero:
+    """lambda_ defaults to 0.0, so default fits match an explicit lambda_=0 fit."""
+
+    def test_logistic(self, logistic_data):
+        x, y = logistic_data
+        default = Logistic(max_iter=100).fit(x, y)
+        explicit = Logistic(max_iter=100, lambda_=0.0).fit(x, y)
+        np.testing.assert_allclose(
+            default.coefficients, explicit.coefficients, rtol=1e-10
+        )
+
+    def test_poisson(self, count_data):
+        x, y = count_data
+        default = Poisson(max_iter=100).fit(x, y)
+        explicit = Poisson(max_iter=100, lambda_=0.0).fit(x, y)
+        np.testing.assert_allclose(
+            default.coefficients, explicit.coefficients, rtol=1e-10
+        )
+
+
+class TestTweedieFactoryConstructorsAcceptLambda:
+    """Tweedie's gaussian/gamma/inverse_gaussian classmethods should also accept lambda_."""
+
+    @pytest.fixture
+    def positive_data(self):
+        np.random.seed(45)
+        n = 200
+        x = np.random.randn(n, 2) * 0.3
+        y = np.exp(0.5 + 0.3 * x[:, 0] - 0.2 * x[:, 1]) + np.abs(
+            np.random.randn(n) * 0.1
+        )
+        # Ensure strictly positive for gamma
+        y = np.maximum(y, 0.01)
+        return x, y
+
+    def test_gaussian(self, positive_data):
+        x, y = positive_data
+        unreg = Tweedie.gaussian(max_iter=200).fit(x, y)
+        strong = Tweedie.gaussian(max_iter=200, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)
+
+    def test_gamma(self, positive_data):
+        x, y = positive_data
+        unreg = Tweedie.gamma(max_iter=200).fit(x, y)
+        strong = Tweedie.gamma(max_iter=200, lambda_=1.0).fit(x, y)
+        assert _coef_norm(strong) < _coef_norm(unreg)


### PR DESCRIPTION
Closes #15.

## Background

The audit for issue #13 flagged that penalized IRLS (added to anofox-regression in 0.5.1 via `.lambda()` on each GLM builder) was "not exposed in Python or Polars." Closer inspection shows the **Polars expression layer already wires `lambda_` end-to-end** for all six GLMs — only the PyClass model wrappers ignore it.

## Changes

Add a `lambda_=0.0` kwarg to all six GLM PyClasses and pipe it into the builder via `.lambda(slf.lambda_)`:

- `Logistic` (PyLogistic → `BinomialRegressor::logistic()`)
- `Poisson` (PyPoisson → `PoissonRegressor::log()`)
- `NegativeBinomial`
- `Tweedie` — plus its three convenience constructors `gaussian` / `gamma` / `inverse_gaussian`
- `Probit` (PyProbit → `BinomialRegressor::probit()`)
- `Cloglog` (PyCloglog → `BinomialRegressor::cloglog()`)

No changes to the Polars expression layer — it already supports `lambda_`. No changes to the Rust `*_fit` entry points.

## Tests

`tests/test_glm_lambda.py` — 10 new tests:

- **Shrinkage** (6 tests): for each GLM, assert that `lambda_ > 0` produces a smaller coefficient L2 norm than the unregularized default.
- **No-op default** (2 tests): assert `Logistic()` ≡ `Logistic(lambda_=0.0)` and same for `Poisson`, to guarantee the kwarg is non-breaking.
- **Tweedie convenience constructors** (2 tests): `Tweedie.gaussian` and `Tweedie.gamma` accept and apply `lambda_`.

Full Python suite: 389/389 pass (379 prior + 10 new).

## Test plan

- [x] `cargo build` clean (no clippy/fmt issues)
- [x] `pytest` — 389/389 pass
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)