### PR TITLE
Wrap VIF, leverage, and Cook's distance diagnostics (partial #17)

### DIFF
--- a/python/polars_statistics/__init__.py
+++ b/python/polars_statistics/__init__.py
@@ -126,6 +126,9 @@ from polars_statistics.exprs import (
     condition_number,
     check_binary_separation,
     check_count_sparsity,
+    vif,
+    leverage,
+    cooks_distance,
     # GLM expressions
     logistic,
     logistic_regression,
@@ -329,6 +332,9 @@ __all__ = [
     "condition_number",
     "check_binary_separation",
     "check_count_sparsity",
+    "vif",
+    "leverage",
+    "cooks_distance",
     # GLM expressions
     "logistic",
     "logistic_regression",

--- a/python/polars_statistics/exprs/__init__.py
+++ b/python/polars_statistics/exprs/__init__.py
@@ -82,6 +82,9 @@ from polars_statistics.exprs.regression import (
     condition_number,
     check_binary_separation,
     check_count_sparsity,
+    vif,
+    leverage,
+    cooks_distance,
     # GLM
     logistic,
     logistic_regression,
@@ -235,6 +238,9 @@ __all__ = [
     "condition_number",
     "check_binary_separation",
     "check_count_sparsity",
+    "vif",
+    "leverage",
+    "cooks_distance",
     # GLM expressions
     "logistic",
     "logistic_regression",

--- a/python/polars_statistics/exprs/regression.py
+++ b/python/polars_statistics/exprs/regression.py
@@ -952,6 +952,171 @@ def check_count_sparsity(
     )
 
 
+def vif(*x: Union[pl.Expr, str]) -> pl.Expr:
+    """Variance Inflation Factor (VIF) for multicollinearity detection.
+
+    VIF measures how much the variance of a coefficient estimate is inflated
+    by multicollinearity. For predictor j:
+
+        VIF_j = 1 / (1 - R²_j)
+
+    where R²_j is the R² from regressing x_j on all other predictors.
+
+    Parameters
+    ----------
+    *x : pl.Expr or str
+        Feature variables (two or more required). The intercept is NOT
+        included — VIF is defined per predictor only.
+
+    Returns
+    -------
+    pl.Expr
+        Struct containing:
+        - terms: List[str] with one entry per feature column (``x1``, ``x2``, ...)
+        - vif: List[float] with one VIF value per feature
+        - n_observations: number of rows used
+
+    Interpretation
+    --------------
+    - VIF = 1: no collinearity with the other predictors
+    - VIF > 5: moderate multicollinearity
+    - VIF > 10: severe multicollinearity (estimates may be unreliable)
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> import polars_statistics as ps
+    >>> df = pl.DataFrame({"x1": [...], "x2": [...], "x3": [...]})
+    >>> df.select(ps.vif("x1", "x2", "x3").alias("vif"))
+    """
+    x_exprs = []
+    for xi in x:
+        if isinstance(xi, str):
+            xi = pl.col(xi)
+        x_exprs.append(xi.cast(pl.Float64))
+
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_vif",
+        args=x_exprs,
+        returns_scalar=True,
+    )
+
+
+def leverage(
+    *x: Union[pl.Expr, str],
+    add_intercept: bool | None = None,
+    with_intercept: bool | None = None,
+) -> pl.Expr:
+    """Leverage (hat matrix diagonal) for each observation.
+
+    Leverage h_ii measures the influence of observation i on its own fitted
+    value. It is the i-th diagonal element of H = X (X'X)^(-1) X'. Properties:
+
+    - 0 ≤ h_ii ≤ 1
+    - Σ h_ii = p (number of parameters)
+    - Points with h_ii > 2p/n are typically considered high-leverage.
+
+    Parameters
+    ----------
+    *x : pl.Expr or str
+        Feature variables.
+    add_intercept : bool, default True
+        Whether to include an intercept column in the design matrix.
+
+    Returns
+    -------
+    pl.Expr
+        Struct containing:
+        - leverage: List[float] with one value per input row
+        - n_observations: number of rows used
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> import polars_statistics as ps
+    >>> df = pl.DataFrame({"x1": [...], "x2": [...]})
+    >>> df.select(ps.leverage("x1", "x2").alias("h"))
+    """
+    add_intercept = _resolve_intercept(add_intercept, with_intercept)
+    x_exprs = []
+    for xi in x:
+        if isinstance(xi, str):
+            xi = pl.col(xi)
+        x_exprs.append(xi.cast(pl.Float64))
+
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_leverage",
+        args=[
+            pl.lit(add_intercept, dtype=pl.Boolean),
+            *x_exprs,
+        ],
+        returns_scalar=True,
+    )
+
+
+def cooks_distance(
+    y: Union[pl.Expr, str],
+    *x: Union[pl.Expr, str],
+    add_intercept: bool | None = None,
+    with_intercept: bool | None = None,
+) -> pl.Expr:
+    """Cook's distance for each observation under an OLS fit.
+
+    Cook's distance combines residual size and leverage to identify
+    observations that disproportionately influence the fitted regression:
+
+        D_i = (e_i² / (p · MSE)) · (h_ii / (1 - h_ii)²)
+
+    Observations with D_i > 4/n (or D_i > 1) are commonly flagged as
+    influential.
+
+    Parameters
+    ----------
+    y : pl.Expr or str
+        Response variable.
+    *x : pl.Expr or str
+        Feature variables.
+    add_intercept : bool, default True
+        Whether to include an intercept column when fitting the OLS model
+        and computing leverage.
+
+    Returns
+    -------
+    pl.Expr
+        Struct containing:
+        - cooks_d: List[float] with one Cook's distance value per input row
+        - n_observations: number of rows used
+
+    Notes
+    -----
+    Internally fits an OLS model to obtain residuals and MSE; the leverage
+    component reuses the same design matrix. The fit is discarded after the
+    diagnostic is computed.
+    """
+    add_intercept = _resolve_intercept(add_intercept, with_intercept)
+    if isinstance(y, str):
+        y = pl.col(y)
+
+    x_exprs = []
+    for xi in x:
+        if isinstance(xi, str):
+            xi = pl.col(xi)
+        x_exprs.append(xi.cast(pl.Float64))
+
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_cooks_distance",
+        args=[
+            y.cast(pl.Float64),
+            pl.lit(add_intercept, dtype=pl.Boolean),
+            *x_exprs,
+        ],
+        returns_scalar=True,
+    )
+
+
 # ============================================================================
 # GLM Expressions
 # ============================================================================

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -8,8 +8,8 @@ use pyo3_polars::derive::polars_expr;
 use serde::Deserialize;
 
 use anofox_regression::diagnostics::{
-    check_binary_separation, check_count_sparsity, condition_diagnostic, ConditionSeverity,
-    SeparationCheck, SeparationType,
+    check_binary_separation, check_count_sparsity, compute_leverage, condition_diagnostic,
+    cooks_distance, variance_inflation_factor, ConditionSeverity, SeparationCheck, SeparationType,
 };
 use anofox_regression::solvers::{
     AidClassifier, AlmDistribution, AlmLoss, AlmRegressor, AnomalyType, BinomialRegressor,
@@ -147,6 +147,43 @@ fn separation_check_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field>
         Field::new("warning".into(), DataType::String),
     ];
     Ok(Field::new("separation".into(), DataType::Struct(fields)))
+}
+
+/// Output type for variance inflation factor (VIF) diagnostics.
+fn vif_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
+    let fields = vec![
+        Field::new("terms".into(), DataType::List(Box::new(DataType::String))),
+        Field::new("vif".into(), DataType::List(Box::new(DataType::Float64))),
+        Field::new("n_observations".into(), DataType::UInt32),
+    ];
+    Ok(Field::new("vif".into(), DataType::Struct(fields)))
+}
+
+/// Output type for leverage (hat matrix diagonal) diagnostics.
+fn leverage_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
+    let fields = vec![
+        Field::new(
+            "leverage".into(),
+            DataType::List(Box::new(DataType::Float64)),
+        ),
+        Field::new("n_observations".into(), DataType::UInt32),
+    ];
+    Ok(Field::new("leverage".into(), DataType::Struct(fields)))
+}
+
+/// Output type for Cook's distance diagnostics.
+fn cooks_distance_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
+    let fields = vec![
+        Field::new(
+            "cooks_d".into(),
+            DataType::List(Box::new(DataType::Float64)),
+        ),
+        Field::new("n_observations".into(), DataType::UInt32),
+    ];
+    Ok(Field::new(
+        "cooks_distance".into(),
+        DataType::Struct(fields),
+    ))
 }
 
 // ============================================================================
@@ -1168,6 +1205,199 @@ pub fn check_count_sparsity_fit(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type_func=separation_check_output_dtype)]
 fn pl_check_count_sparsity(inputs: &[Series]) -> PolarsResult<Series> {
     check_count_sparsity_fit(inputs)
+}
+
+// ----------------------------------------------------------------------------
+// Multicollinearity / influence diagnostics
+// ----------------------------------------------------------------------------
+
+/// Build a VIF output struct (terms, vif, n_observations).
+fn vif_output(terms: Vec<String>, vif: Vec<f64>, n_obs: usize) -> PolarsResult<Series> {
+    let terms_inner = Series::new("item".into(), terms);
+    let terms_s = Series::new("terms".into(), &[terms_inner]);
+    let vif_inner = Series::new("item".into(), vif);
+    let vif_s = Series::new("vif".into(), &[vif_inner]);
+    let n_obs_s = Series::new("n_observations".into(), &[n_obs as u32]);
+
+    StructChunked::from_series("vif".into(), 1, [&terms_s, &vif_s, &n_obs_s].into_iter())
+        .map(|ca| ca.into_series())
+}
+
+/// Empty/NaN output for VIF on error.
+fn vif_nan_output() -> PolarsResult<Series> {
+    vif_output(vec![], vec![], 0)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_vif` expression shim.
+///
+/// Input contract: `[x_0, x_1, ...]` (raw features only; no `y`, no intercept flag).
+/// VIF is computed per predictor, so an intercept column is not part of the input.
+pub fn vif_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    if inputs.is_empty() {
+        return vif_nan_output();
+    }
+    let n_features = inputs.len();
+    let n_rows = inputs[0].len();
+    if n_rows < 3 || n_features == 0 {
+        return vif_nan_output();
+    }
+
+    // Build X matrix from raw features.
+    let x = Mat::from_fn(n_rows, n_features, |row, col| {
+        inputs[col]
+            .f64()
+            .ok()
+            .and_then(|ca| ca.get(row))
+            .unwrap_or(f64::NAN)
+    });
+
+    // Bail on NaN inputs.
+    for i in 0..n_rows {
+        for j in 0..n_features {
+            if x[(i, j)].is_nan() {
+                return vif_nan_output();
+            }
+        }
+    }
+
+    let vif_col = variance_inflation_factor(&x);
+    let vif_vec: Vec<f64> = (0..vif_col.nrows()).map(|i| vif_col[i]).collect();
+    let terms = build_term_names(n_features, false);
+
+    vif_output(terms, vif_vec, n_rows)
+}
+
+/// Variance inflation factor (VIF) diagnostic expression.
+/// inputs[0..] = x columns (raw features only).
+#[polars_expr(output_type_func=vif_output_dtype)]
+fn pl_vif(inputs: &[Series]) -> PolarsResult<Series> {
+    vif_fit(inputs)
+}
+
+/// Build a leverage output struct (leverage values per row, n_observations).
+fn leverage_output(values: Vec<f64>, n_obs: usize) -> PolarsResult<Series> {
+    let inner = Series::new("item".into(), values);
+    let lev_s = Series::new("leverage".into(), &[inner]);
+    let n_obs_s = Series::new("n_observations".into(), &[n_obs as u32]);
+
+    StructChunked::from_series("leverage".into(), 1, [&lev_s, &n_obs_s].into_iter())
+        .map(|ca| ca.into_series())
+}
+
+/// Empty/NaN output for leverage on error.
+fn leverage_nan_output() -> PolarsResult<Series> {
+    leverage_output(vec![], 0)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_leverage` expression shim.
+///
+/// Input contract: `[with_intercept (bool scalar), x_0, x_1, ...]`.
+pub fn leverage_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    if inputs.is_empty() {
+        return leverage_nan_output();
+    }
+    let with_intercept = inputs[0].bool()?.get(0).unwrap_or(true);
+
+    let n_features = inputs.len() - 1;
+    if n_features == 0 {
+        return leverage_nan_output();
+    }
+    let n_rows = inputs[1].len();
+    if n_rows < 2 {
+        return leverage_nan_output();
+    }
+
+    let x = Mat::from_fn(n_rows, n_features, |row, col| {
+        inputs[1 + col]
+            .f64()
+            .ok()
+            .and_then(|ca| ca.get(row))
+            .unwrap_or(f64::NAN)
+    });
+
+    for i in 0..n_rows {
+        for j in 0..n_features {
+            if x[(i, j)].is_nan() {
+                return leverage_nan_output();
+            }
+        }
+    }
+
+    let lev_col = compute_leverage(&x, with_intercept);
+    let values: Vec<f64> = (0..lev_col.nrows()).map(|i| lev_col[i]).collect();
+    leverage_output(values, n_rows)
+}
+
+/// Leverage (hat matrix diagonal) diagnostic expression.
+/// inputs[0] = with_intercept (bool), inputs[1..] = x columns.
+#[polars_expr(output_type_func=leverage_output_dtype)]
+fn pl_leverage(inputs: &[Series]) -> PolarsResult<Series> {
+    leverage_fit(inputs)
+}
+
+/// Build a Cook's distance output struct (one value per row, n_observations).
+fn cooks_distance_output(values: Vec<f64>, n_obs: usize) -> PolarsResult<Series> {
+    let inner = Series::new("item".into(), values);
+    let cooks_s = Series::new("cooks_d".into(), &[inner]);
+    let n_obs_s = Series::new("n_observations".into(), &[n_obs as u32]);
+
+    StructChunked::from_series("cooks_distance".into(), 1, [&cooks_s, &n_obs_s].into_iter())
+        .map(|ca| ca.into_series())
+}
+
+/// Empty/NaN output for Cook's distance on error.
+fn cooks_distance_nan_output() -> PolarsResult<Series> {
+    cooks_distance_output(vec![], 0)
+}
+
+/// Public Rust-callable variant. Same input contract as the `pl_cooks_distance` expression shim.
+///
+/// Input contract: `[y, with_intercept (bool scalar), x_0, x_1, ...]`.
+///
+/// Internally fits an OLS regression to obtain residuals and MSE, then combines them
+/// with the leverage values for the same design to compute Cook's distance per row.
+pub fn cooks_distance_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    if inputs.len() < 3 {
+        return cooks_distance_nan_output();
+    }
+    let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
+    let n_features = inputs.len() - 2;
+
+    let (x, y) = match build_xy_data(inputs, 0, 2) {
+        Ok(data) => data,
+        Err(_) => return cooks_distance_nan_output(),
+    };
+
+    let n_rows = x.nrows();
+    if n_rows < 2 || n_features == 0 {
+        return cooks_distance_nan_output();
+    }
+
+    let model = OlsRegressor::builder()
+        .with_intercept(with_intercept)
+        .build();
+    let fitted = match model.fit(&x, &y) {
+        Ok(f) => f,
+        Err(_) => return cooks_distance_nan_output(),
+    };
+
+    let result = fitted.result();
+    let residuals = &result.residuals;
+    let mse = result.mse;
+
+    let leverage = compute_leverage(&x, with_intercept);
+    let n_params = n_features + if with_intercept { 1 } else { 0 };
+
+    let cooks = cooks_distance(residuals, &leverage, mse, n_params);
+    let values: Vec<f64> = (0..cooks.nrows()).map(|i| cooks[i]).collect();
+    cooks_distance_output(values, n_rows)
+}
+
+/// Cook's distance diagnostic expression.
+/// inputs[0] = y, inputs[1] = with_intercept (bool), inputs[2..] = x columns.
+#[polars_expr(output_type_func=cooks_distance_output_dtype)]
+fn pl_cooks_distance(inputs: &[Series]) -> PolarsResult<Series> {
+    cooks_distance_fit(inputs)
 }
 
 // ============================================================================

--- a/tests/rust_api.rs
+++ b/tests/rust_api.rs
@@ -845,6 +845,51 @@ fn diagnostic_fits() {
         let st = out.struct_().unwrap();
         let _has = st.field_by_name("has_separation").unwrap();
     }
+
+    // vif_fit: only x columns; needs at least 2 features for a meaningful VIF.
+    // Use two independent predictors so VIF should be close to 1.
+    {
+        let x_a: Vec<f64> = (0..30).map(|i| (i as f64 * 0.3).sin()).collect();
+        let x_b: Vec<f64> = (0..30).map(|i| (i as f64 * 0.3).cos()).collect();
+        let inputs = vec![series_f64("x1", &x_a), series_f64("x2", &x_b)];
+        let out = vif_fit(&inputs).expect("vif_fit failed");
+        let st = out.struct_().unwrap();
+        let _terms = st.field_by_name("terms").unwrap();
+        let _vif = st.field_by_name("vif").unwrap();
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // leverage_fit: with_intercept (bool), x columns.
+    {
+        let inputs = vec![
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let out = leverage_fit(&inputs).expect("leverage_fit failed");
+        let st = out.struct_().unwrap();
+        let _lev = st.field_by_name("leverage").unwrap();
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
+
+    // cooks_distance_fit: y, with_intercept (bool), x columns.
+    {
+        let y_vals: Vec<f64> = x1
+            .iter()
+            .enumerate()
+            .map(|(i, xi)| 0.5 + 1.5 * xi + 0.1 * (i as f64).sin())
+            .collect();
+        let inputs = vec![
+            series_f64("y", &y_vals),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let out = cooks_distance_fit(&inputs).expect("cooks_distance_fit failed");
+        let st = out.struct_().unwrap();
+        let _cd = st.field_by_name("cooks_d").unwrap();
+        assert_n_obs_nonzero(&out, "n_observations");
+    }
 }
 
 // =============================================================================

--- a/tests/test_diagnostics_toolkit.py
+++ b/tests/test_diagnostics_toolkit.py
@@ -1,0 +1,120 @@
+"""Tests for the diagnostics toolkit expressions: VIF, leverage, Cook's distance.
+
+These tests check the property contracts of the diagnostics rather than exact
+numerical values (which are validated upstream in anofox-regression).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+import polars_statistics as ps
+
+
+def test_vif_orthogonal_predictors_near_one():
+    """Independent predictors should yield VIF values near 1.0."""
+    rng = np.random.default_rng(seed=42)
+    n = 200
+    x1 = rng.standard_normal(n)
+    x2 = rng.standard_normal(n)
+    x3 = rng.standard_normal(n)
+
+    df = pl.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+    result = df.select(ps.vif("x1", "x2", "x3").alias("vif"))
+
+    row = result["vif"][0]
+    terms = list(row["terms"])
+    vif_values = list(row["vif"])
+    n_obs = row["n_observations"]
+
+    assert n_obs == n
+    assert terms == ["x1", "x2", "x3"]
+    assert len(vif_values) == 3
+    for v in vif_values:
+        # Independent draws should give VIF very close to 1.
+        assert v >= 1.0 - 1e-9
+        assert v < 1.5, f"VIF should be near 1 for independent predictors, got {v}"
+
+
+def test_vif_collinear_predictors_high():
+    """Highly collinear predictors should yield VIF > 5 (typical concern threshold)."""
+    rng = np.random.default_rng(seed=123)
+    n = 150
+    x1 = rng.standard_normal(n)
+    # x2 is x1 with a tiny perturbation -> near-perfect collinearity.
+    x2 = x1 + 0.01 * rng.standard_normal(n)
+    x3 = rng.standard_normal(n)  # independent
+
+    df = pl.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+    result = df.select(ps.vif("x1", "x2", "x3").alias("vif"))
+
+    vif_values = list(result["vif"][0]["vif"])
+    assert vif_values[0] > 5.0
+    assert vif_values[1] > 5.0
+    # x3 should be unaffected.
+    assert vif_values[2] < 1.5
+
+
+def test_leverage_sum_equals_n_params():
+    """Sum of leverage values equals the number of parameters (hat-matrix trace)."""
+    rng = np.random.default_rng(seed=7)
+    n = 120
+    x1 = rng.standard_normal(n)
+    x2 = rng.standard_normal(n)
+
+    df = pl.DataFrame({"x1": x1, "x2": x2})
+
+    # With intercept: trace(H) = p = 3 (intercept + 2 features).
+    res_with = df.select(ps.leverage("x1", "x2", add_intercept=True).alias("h"))
+    lev_with = list(res_with["h"][0]["leverage"])
+    assert len(lev_with) == n
+    assert all(0.0 <= h <= 1.0 for h in lev_with)
+    assert abs(sum(lev_with) - 3.0) < 1e-6
+
+    # Without intercept: trace(H) = p = 2.
+    res_no = df.select(ps.leverage("x1", "x2", add_intercept=False).alias("h"))
+    lev_no = list(res_no["h"][0]["leverage"])
+    assert len(lev_no) == n
+    assert abs(sum(lev_no) - 2.0) < 1e-6
+
+
+def test_cooks_distance_non_negative_one_per_row():
+    """Cook's distance returns one non-negative value per input row."""
+    rng = np.random.default_rng(seed=99)
+    n = 80
+    x1 = rng.standard_normal(n)
+    x2 = rng.standard_normal(n)
+    y = 1.0 + 2.0 * x1 - 0.5 * x2 + 0.3 * rng.standard_normal(n)
+
+    df = pl.DataFrame({"y": y, "x1": x1, "x2": x2})
+    result = df.select(ps.cooks_distance("y", "x1", "x2").alias("cd"))
+
+    row = result["cd"][0]
+    cd_values = list(row["cooks_d"])
+    n_obs = row["n_observations"]
+
+    assert n_obs == n
+    assert len(cd_values) == n
+    # All Cook's distances are non-negative by construction.
+    for v in cd_values:
+        assert v >= 0.0, f"Cook's distance must be non-negative, got {v}"
+        assert np.isfinite(v), f"Cook's distance must be finite, got {v}"
+
+
+def test_cooks_distance_flags_outlier():
+    """Injecting an outlier should produce a high Cook's distance at that row."""
+    rng = np.random.default_rng(seed=2024)
+    n = 100
+    x = rng.standard_normal(n)
+    y = 1.0 + 1.5 * x + 0.1 * rng.standard_normal(n)
+    # Inject a big residual at the last row.
+    y[-1] = y[-1] + 20.0
+
+    df = pl.DataFrame({"y": y, "x": x})
+    result = df.select(ps.cooks_distance("y", "x").alias("cd"))
+    cd_values = np.asarray(list(result["cd"][0]["cooks_d"]))
+
+    # The injected row should have the maximum Cook's distance.
+    assert int(np.argmax(cd_values)) == n - 1
+    assert cd_values[-1] > np.median(cd_values) * 10


### PR DESCRIPTION
Partial close for #17. The audit listed 21 diagnostic functions in `anofox_regression::diagnostics`. This PR ships the 3 most-used ones; a follow-up will cover the residual battery.

## Implemented

| Diagnostic | Expression | Use case |
|---|---|---|
| VIF | `ps.vif("x1", "x2", ...)` | Multicollinearity: per-feature variance inflation factor |
| Leverage | `ps.leverage("x1", "x2", ...)` | Per-row hat-matrix diagonal |
| Cook's distance | `ps.cooks_distance("y", "x1", "x2", ...)` | Per-row influence on regression coefficients |

All three follow the rlib split pattern from #13 — public `*_fit` functions plus `pl_*` shim wrappers.

## Output shape

Each diagnostic returns one struct per group with the per-feature or per-row diagnostic vector as a `List<Float64>` plus `n_observations`. Same pattern as `ols_summary`.

```python
df.group_by("group").agg(
    ps.vif("x1", "x2", "x3").alias("vif")
).explode("vif")  # then unnest as needed
```

## Tests

- **Python** — `tests/test_diagnostics_toolkit.py`, 5 new pytests:
  - VIF returns high values (>5) on correlated features, ~1.0 on independent features.
  - Leverage diagonal sums to `n_params` (known hat-matrix trace property).
  - Cook's distance is non-negative for every row.
  - All three return the expected `n_observations` field.
- **Rust** — `tests/rust_api.rs`: 3 smoke-test blocks appended to `diagnostic_fits`.

Full Python suite: 413/413 pass. Rust integration: 12/12 pass.

## Deferred — will file as a follow-up issue

The residual battery and remaining influence diagnostics:

- `standardized_residuals`, `studentized_residuals`, `externally_studentized_residuals`, `residual_outliers`
- `pearson_residuals`, `deviance_residuals`, `working_residuals`, `response_residuals`
- `standardized_pearson_residuals`, `standardized_deviance_residuals`
- `dffits`, `influential_cooks`, `influential_dffits`, `high_leverage_points`, `high_vif_predictors`
- `pearson_chi_squared`, `estimate_dispersion_pearson`, `estimate_dispersion_deviance`
- `classify_condition_number`, `variance_decomposition_proportions`, `generalized_vif`

These are all available in `anofox_regression::diagnostics` and follow the same wrapper pattern. Splitting keeps this PR reviewable.

## Test plan

- [x] `cargo build --no-default-features` clean
- [x] `cargo test --no-default-features` — 12/12 pass
- [x] `cargo build` clean
- [x] `pytest` — 413/413 pass
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)