### PR TITLE
Wrap OLS residual diagnostics (#27 batch 1)

### DIFF
--- a/python/polars_statistics/__init__.py
+++ b/python/polars_statistics/__init__.py
@@ -129,6 +129,10 @@ from polars_statistics.exprs import (
     vif,
     leverage,
     cooks_distance,
+    standardized_residuals,
+    studentized_residuals,
+    externally_studentized_residuals,
+    residual_outliers,
     # GLM expressions
     logistic,
     logistic_regression,
@@ -340,6 +344,10 @@ __all__ = [
     "vif",
     "leverage",
     "cooks_distance",
+    "standardized_residuals",
+    "studentized_residuals",
+    "externally_studentized_residuals",
+    "residual_outliers",
     # GLM expressions
     "logistic",
     "logistic_regression",

--- a/python/polars_statistics/exprs/__init__.py
+++ b/python/polars_statistics/exprs/__init__.py
@@ -85,6 +85,10 @@ from polars_statistics.exprs.regression import (
     vif,
     leverage,
     cooks_distance,
+    standardized_residuals,
+    studentized_residuals,
+    externally_studentized_residuals,
+    residual_outliers,
     # GLM
     logistic,
     logistic_regression,
@@ -246,6 +250,10 @@ __all__ = [
     "vif",
     "leverage",
     "cooks_distance",
+    "standardized_residuals",
+    "studentized_residuals",
+    "externally_studentized_residuals",
+    "residual_outliers",
     # GLM expressions
     "logistic",
     "logistic_regression",

--- a/python/polars_statistics/exprs/regression.py
+++ b/python/polars_statistics/exprs/regression.py
@@ -1117,6 +1117,107 @@ def cooks_distance(
     )
 
 
+def _residual_diag_args(y, x, add_intercept):
+    if isinstance(y, str):
+        y = pl.col(y)
+    x_exprs = [(pl.col(xi) if isinstance(xi, str) else xi).cast(pl.Float64) for xi in x]
+    return [y.cast(pl.Float64), pl.lit(add_intercept, dtype=pl.Boolean), *x_exprs]
+
+
+def standardized_residuals(
+    y: Union[pl.Expr, str],
+    *x: Union[pl.Expr, str],
+    add_intercept: bool | None = None,
+    with_intercept: bool | None = None,
+) -> pl.Expr:
+    """Standardized residuals (r_i / sqrt(MSE)) from an internal OLS fit.
+
+    Returns a struct with ``residuals`` (List[float]) and ``n_observations``.
+    """
+    add_intercept = _resolve_intercept(add_intercept, with_intercept)
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_standardized_residuals",
+        args=_residual_diag_args(y, x, add_intercept),
+        returns_scalar=True,
+    )
+
+
+def studentized_residuals(
+    y: Union[pl.Expr, str],
+    *x: Union[pl.Expr, str],
+    add_intercept: bool | None = None,
+    with_intercept: bool | None = None,
+) -> pl.Expr:
+    """Internally studentized residuals — r_i / sqrt(MSE · (1 - h_ii)) — from an
+    internal OLS fit.
+
+    Returns a struct with ``residuals`` (List[float]) and ``n_observations``.
+    """
+    add_intercept = _resolve_intercept(add_intercept, with_intercept)
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_studentized_residuals",
+        args=_residual_diag_args(y, x, add_intercept),
+        returns_scalar=True,
+    )
+
+
+def externally_studentized_residuals(
+    y: Union[pl.Expr, str],
+    *x: Union[pl.Expr, str],
+    add_intercept: bool | None = None,
+    with_intercept: bool | None = None,
+) -> pl.Expr:
+    """Externally studentized residuals (leave-one-out) from an internal OLS fit.
+
+    Follow a t-distribution with ``n - p - 1`` degrees of freedom under the
+    null hypothesis that observation ``i`` is not an outlier.
+
+    Returns a struct with ``residuals`` (List[float]) and ``n_observations``.
+    """
+    add_intercept = _resolve_intercept(add_intercept, with_intercept)
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_externally_studentized_residuals",
+        args=_residual_diag_args(y, x, add_intercept),
+        returns_scalar=True,
+    )
+
+
+def residual_outliers(
+    y: Union[pl.Expr, str],
+    *x: Union[pl.Expr, str],
+    threshold: float = 2.0,
+    add_intercept: bool | None = None,
+    with_intercept: bool | None = None,
+) -> pl.Expr:
+    """Boolean outlier mask from studentized residuals.
+
+    Flags observations whose internally-studentized residual exceeds the
+    given threshold in absolute value (default 2.0 — roughly the 95% CI on
+    standardized residuals).
+
+    Returns a struct with ``is_outlier`` (List[bool]), ``n_outliers`` and
+    ``n_observations``.
+    """
+    add_intercept = _resolve_intercept(add_intercept, with_intercept)
+    if isinstance(y, str):
+        y = pl.col(y)
+    x_exprs = [(pl.col(xi) if isinstance(xi, str) else xi).cast(pl.Float64) for xi in x]
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name="pl_residual_outliers",
+        args=[
+            y.cast(pl.Float64),
+            pl.lit(add_intercept, dtype=pl.Boolean),
+            pl.lit(threshold, dtype=pl.Float64),
+            *x_exprs,
+        ],
+        returns_scalar=True,
+    )
+
+
 # ============================================================================
 # GLM Expressions
 # ============================================================================

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -9,7 +9,9 @@ use serde::Deserialize;
 
 use anofox_regression::diagnostics::{
     check_binary_separation, check_count_sparsity, compute_leverage, condition_diagnostic,
-    cooks_distance, variance_inflation_factor, ConditionSeverity, SeparationCheck, SeparationType,
+    cooks_distance, externally_studentized_residuals, residual_outliers, standardized_residuals,
+    studentized_residuals, variance_inflation_factor, ConditionSeverity, SeparationCheck,
+    SeparationType,
 };
 use anofox_regression::solvers::{
     AidClassifier, AlmDistribution, AlmLoss, AlmRegressor, AnomalyType, BinomialRegressor,
@@ -184,6 +186,35 @@ fn cooks_distance_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
         "cooks_distance".into(),
         DataType::Struct(fields),
     ))
+}
+
+/// Output type for per-row residual diagnostics (standardized / studentized /
+/// externally studentized).
+fn residual_diag_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
+    let fields = vec![
+        Field::new(
+            "residuals".into(),
+            DataType::List(Box::new(DataType::Float64)),
+        ),
+        Field::new("n_observations".into(), DataType::UInt32),
+    ];
+    Ok(Field::new(
+        "residual_diagnostics".into(),
+        DataType::Struct(fields),
+    ))
+}
+
+/// Output type for the residual outlier mask: boolean per row + count.
+fn outlier_mask_output_dtype(_input_fields: &[Field]) -> PolarsResult<Field> {
+    let fields = vec![
+        Field::new(
+            "is_outlier".into(),
+            DataType::List(Box::new(DataType::Boolean)),
+        ),
+        Field::new("n_outliers".into(), DataType::UInt32),
+        Field::new("n_observations".into(), DataType::UInt32),
+    ];
+    Ok(Field::new("outliers".into(), DataType::Struct(fields)))
 }
 
 // ============================================================================
@@ -1440,6 +1471,163 @@ pub fn cooks_distance_fit(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type_func=cooks_distance_output_dtype)]
 fn pl_cooks_distance(inputs: &[Series]) -> PolarsResult<Series> {
     cooks_distance_fit(inputs)
+}
+
+/// Build a residual-diagnostic output struct (one value per row, n_observations).
+fn residual_diag_output(values: Vec<f64>, n_obs: usize) -> PolarsResult<Series> {
+    let inner = Series::new("item".into(), values);
+    let r_s = Series::new("residuals".into(), &[inner]);
+    let n_obs_s = Series::new("n_observations".into(), &[n_obs as u32]);
+    StructChunked::from_series(
+        "residual_diagnostics".into(),
+        1,
+        [&r_s, &n_obs_s].into_iter(),
+    )
+    .map(|ca| ca.into_series())
+}
+
+fn residual_diag_nan_output() -> PolarsResult<Series> {
+    residual_diag_output(vec![], 0)
+}
+
+/// Internal helper: fit OLS and return (residuals, leverage, mse, n_params, n_rows).
+/// Returns None on any failure.
+fn fit_ols_for_residual_diag(
+    inputs: &[Series],
+) -> Option<(Col<f64>, Col<f64>, f64, usize, usize)> {
+    if inputs.len() < 3 {
+        return None;
+    }
+    let with_intercept = inputs[1].bool().ok()?.get(0).unwrap_or(true);
+    let n_features = inputs.len() - 2;
+    let (x, y) = build_xy_data(inputs, 0, 2).ok()?;
+    let n_rows = x.nrows();
+    if n_rows < 2 || n_features == 0 {
+        return None;
+    }
+    let model = OlsRegressor::builder()
+        .with_intercept(with_intercept)
+        .build();
+    let fitted = model.fit(&x, &y).ok()?;
+    let residuals = fitted.result().residuals.clone();
+    let mse = fitted.result().mse;
+    let leverage = compute_leverage(&x, with_intercept);
+    let n_params = n_features + if with_intercept { 1 } else { 0 };
+    Some((residuals, leverage, mse, n_params, n_rows))
+}
+
+/// Standardized residuals (r_i / sqrt(MSE)).
+///
+/// Input contract: `[y, with_intercept (bool), x_0, ...]`.
+pub fn standardized_residuals_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    let (residuals, _leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(inputs)
+    {
+        Some(v) => v,
+        None => return residual_diag_nan_output(),
+    };
+    let r = standardized_residuals(&residuals, mse);
+    let values: Vec<f64> = (0..r.nrows()).map(|i| r[i]).collect();
+    residual_diag_output(values, n_rows)
+}
+
+#[polars_expr(output_type_func=residual_diag_output_dtype)]
+fn pl_standardized_residuals(inputs: &[Series]) -> PolarsResult<Series> {
+    standardized_residuals_fit(inputs)
+}
+
+/// Internally studentized residuals: r_i / sqrt(MSE * (1 - h_ii)).
+///
+/// Input contract: `[y, with_intercept (bool), x_0, ...]`.
+pub fn studentized_residuals_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    let (residuals, leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(inputs)
+    {
+        Some(v) => v,
+        None => return residual_diag_nan_output(),
+    };
+    let r = studentized_residuals(&residuals, &leverage, mse);
+    let values: Vec<f64> = (0..r.nrows()).map(|i| r[i]).collect();
+    residual_diag_output(values, n_rows)
+}
+
+#[polars_expr(output_type_func=residual_diag_output_dtype)]
+fn pl_studentized_residuals(inputs: &[Series]) -> PolarsResult<Series> {
+    studentized_residuals_fit(inputs)
+}
+
+/// Externally studentized residuals (leave-one-out): follow a t-distribution
+/// with `n - p - 1` degrees of freedom.
+///
+/// Input contract: `[y, with_intercept (bool), x_0, ...]`.
+pub fn externally_studentized_residuals_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    let (residuals, leverage, mse, n_params, n_rows) = match fit_ols_for_residual_diag(inputs) {
+        Some(v) => v,
+        None => return residual_diag_nan_output(),
+    };
+    let r = externally_studentized_residuals(&residuals, &leverage, mse, n_params);
+    let values: Vec<f64> = (0..r.nrows()).map(|i| r[i]).collect();
+    residual_diag_output(values, n_rows)
+}
+
+#[polars_expr(output_type_func=residual_diag_output_dtype)]
+fn pl_externally_studentized_residuals(inputs: &[Series]) -> PolarsResult<Series> {
+    externally_studentized_residuals_fit(inputs)
+}
+
+/// Boolean outlier mask from studentized residuals.
+///
+/// Input contract: `[y, with_intercept (bool), threshold (f64), x_0, ...]`.
+/// Returns one boolean per row plus the total outlier count.
+pub fn residual_outliers_fit(inputs: &[Series]) -> PolarsResult<Series> {
+    if inputs.len() < 4 {
+        return residual_outliers_nan_output();
+    }
+    let with_intercept = inputs[1].bool()?.get(0).unwrap_or(true);
+    let threshold = inputs[2].f64()?.get(0).unwrap_or(2.0);
+    let n_features = inputs.len() - 3;
+    // Build the input slice expected by the OLS fit helper: [y, with_intercept, x...]
+    let mut fit_inputs: Vec<Series> = Vec::with_capacity(2 + n_features);
+    fit_inputs.push(inputs[0].clone());
+    fit_inputs.push(inputs[1].clone());
+    fit_inputs.extend(inputs[3..].iter().cloned());
+
+    let (residuals, leverage, mse, _n_params, n_rows) =
+        match fit_ols_for_residual_diag(&fit_inputs) {
+            Some(v) => v,
+            None => return residual_outliers_nan_output(),
+        };
+    let _ = with_intercept; // already consumed by the helper
+    let stud = studentized_residuals(&residuals, &leverage, mse);
+    let outlier_idx = residual_outliers(&stud, threshold);
+    let mut mask = vec![false; n_rows];
+    for i in outlier_idx.iter() {
+        if *i < n_rows {
+            mask[*i] = true;
+        }
+    }
+    let n_outliers = mask.iter().filter(|&&b| b).count();
+    residual_outliers_output(mask, n_outliers, n_rows)
+}
+
+fn residual_outliers_output(
+    mask: Vec<bool>,
+    n_outliers: usize,
+    n_obs: usize,
+) -> PolarsResult<Series> {
+    let inner = Series::new("item".into(), mask);
+    let m_s = Series::new("is_outlier".into(), &[inner]);
+    let no_s = Series::new("n_outliers".into(), &[n_outliers as u32]);
+    let nobs_s = Series::new("n_observations".into(), &[n_obs as u32]);
+    StructChunked::from_series("outliers".into(), 1, [&m_s, &no_s, &nobs_s].into_iter())
+        .map(|ca| ca.into_series())
+}
+
+fn residual_outliers_nan_output() -> PolarsResult<Series> {
+    residual_outliers_output(vec![], 0, 0)
+}
+
+#[polars_expr(output_type_func=outlier_mask_output_dtype)]
+fn pl_residual_outliers(inputs: &[Series]) -> PolarsResult<Series> {
+    residual_outliers_fit(inputs)
 }
 
 // ============================================================================

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -26,6 +26,10 @@ use anofox_regression::{HcType, IntervalType, SolverType};
 /// Result type for build_xy_with_null_policy: (X_fit, y, valid_mask, X_pred)
 type XyNullPolicyResult = (Mat<f64>, Col<f64>, Vec<bool>, Mat<f64>);
 
+/// (residuals, leverage, mse, n_params, n_rows) from a fitted OLS used as
+/// the foundation for per-row residual diagnostics.
+type OlsResidualContext = (Col<f64>, Col<f64>, f64, usize, usize);
+
 /// Parse a solver type string into a SolverType enum.
 fn parse_solver_type(s: Option<&str>) -> Option<SolverType> {
     s.map(|v| match v {
@@ -1492,7 +1496,7 @@ fn residual_diag_nan_output() -> PolarsResult<Series> {
 
 /// Internal helper: fit OLS and return (residuals, leverage, mse, n_params, n_rows).
 /// Returns None on any failure.
-fn fit_ols_for_residual_diag(inputs: &[Series]) -> Option<(Col<f64>, Col<f64>, f64, usize, usize)> {
+fn fit_ols_for_residual_diag(inputs: &[Series]) -> Option<OlsResidualContext> {
     if inputs.len() < 3 {
         return None;
     }

--- a/src/expressions/regression.rs
+++ b/src/expressions/regression.rs
@@ -1492,9 +1492,7 @@ fn residual_diag_nan_output() -> PolarsResult<Series> {
 
 /// Internal helper: fit OLS and return (residuals, leverage, mse, n_params, n_rows).
 /// Returns None on any failure.
-fn fit_ols_for_residual_diag(
-    inputs: &[Series],
-) -> Option<(Col<f64>, Col<f64>, f64, usize, usize)> {
+fn fit_ols_for_residual_diag(inputs: &[Series]) -> Option<(Col<f64>, Col<f64>, f64, usize, usize)> {
     if inputs.len() < 3 {
         return None;
     }
@@ -1520,8 +1518,7 @@ fn fit_ols_for_residual_diag(
 ///
 /// Input contract: `[y, with_intercept (bool), x_0, ...]`.
 pub fn standardized_residuals_fit(inputs: &[Series]) -> PolarsResult<Series> {
-    let (residuals, _leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(inputs)
-    {
+    let (residuals, _leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(inputs) {
         Some(v) => v,
         None => return residual_diag_nan_output(),
     };
@@ -1539,8 +1536,7 @@ fn pl_standardized_residuals(inputs: &[Series]) -> PolarsResult<Series> {
 ///
 /// Input contract: `[y, with_intercept (bool), x_0, ...]`.
 pub fn studentized_residuals_fit(inputs: &[Series]) -> PolarsResult<Series> {
-    let (residuals, leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(inputs)
-    {
+    let (residuals, leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(inputs) {
         Some(v) => v,
         None => return residual_diag_nan_output(),
     };
@@ -1590,11 +1586,11 @@ pub fn residual_outliers_fit(inputs: &[Series]) -> PolarsResult<Series> {
     fit_inputs.push(inputs[1].clone());
     fit_inputs.extend(inputs[3..].iter().cloned());
 
-    let (residuals, leverage, mse, _n_params, n_rows) =
-        match fit_ols_for_residual_diag(&fit_inputs) {
-            Some(v) => v,
-            None => return residual_outliers_nan_output(),
-        };
+    let (residuals, leverage, mse, _n_params, n_rows) = match fit_ols_for_residual_diag(&fit_inputs)
+    {
+        Some(v) => v,
+        None => return residual_outliers_nan_output(),
+    };
     let _ = with_intercept; // already consumed by the helper
     let stud = studentized_residuals(&residuals, &leverage, mse);
     let outlier_idx = residual_outliers(&stud, threshold);

--- a/tests/rust_api.rs
+++ b/tests/rust_api.rs
@@ -932,6 +932,53 @@ fn diagnostic_fits() {
         let _cd = st.field_by_name("cooks_d").unwrap();
         assert_n_obs_nonzero(&out, "n_observations");
     }
+
+    // residual diagnostics (issue #27 batch 1): standardized / studentized /
+    // externally studentized — same input contract as cooks_distance.
+    {
+        let y_vals: Vec<f64> = x1
+            .iter()
+            .enumerate()
+            .map(|(i, xi)| 0.5 + 1.5 * xi + 0.1 * (i as f64).sin())
+            .collect();
+        let inputs = vec![
+            series_f64("y", &y_vals),
+            scalar_bool("with_intercept", true),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let _ = standardized_residuals_fit(&inputs).expect("standardized_residuals_fit failed");
+        let _ = studentized_residuals_fit(&inputs).expect("studentized_residuals_fit failed");
+        let _ = externally_studentized_residuals_fit(&inputs)
+            .expect("externally_studentized_residuals_fit failed");
+    }
+
+    // residual_outliers_fit: y, with_intercept, threshold, x...
+    {
+        let y_vals: Vec<f64> = x1
+            .iter()
+            .enumerate()
+            .map(|(i, xi)| 0.5 + 1.5 * xi + 0.1 * (i as f64).sin())
+            .collect();
+        let inputs = vec![
+            series_f64("y", &y_vals),
+            scalar_bool("with_intercept", true),
+            scalar_f64("threshold", 2.0),
+            series_f64("x1", &x1),
+            series_f64("x2", &x2),
+        ];
+        let out = residual_outliers_fit(&inputs).expect("residual_outliers_fit failed");
+        let st = out.struct_().unwrap();
+        let _ = st.field_by_name("is_outlier").unwrap();
+        let n_obs = st
+            .field_by_name("n_observations")
+            .unwrap()
+            .u32()
+            .unwrap()
+            .get(0)
+            .unwrap_or(0);
+        assert!(n_obs > 0);
+    }
 }
 
 // =============================================================================

--- a/tests/test_residual_diagnostics.py
+++ b/tests/test_residual_diagnostics.py
@@ -1,0 +1,117 @@
+"""Tests for OLS residual diagnostics (issue #27 batch 1)."""
+
+import numpy as np
+import polars as pl
+import pytest
+
+from polars_statistics import (
+    externally_studentized_residuals,
+    residual_outliers,
+    standardized_residuals,
+    studentized_residuals,
+)
+
+
+@pytest.fixture
+def clean_data():
+    """y = 1 + 2x + small noise, no outliers."""
+    rng = np.random.default_rng(0)
+    n = 100
+    x = rng.normal(size=n)
+    y = 1.0 + 2.0 * x + rng.normal(scale=0.3, size=n)
+    return pl.DataFrame({"y": y, "x": x})
+
+
+@pytest.fixture
+def outlier_data():
+    """Same as clean_data but with planted outliers at indices [3, 17, 42]."""
+    rng = np.random.default_rng(1)
+    n = 100
+    x = rng.normal(size=n)
+    y = 1.0 + 2.0 * x + rng.normal(scale=0.3, size=n)
+    for idx in (3, 17, 42):
+        y[idx] += 20.0
+    return pl.DataFrame({"y": y, "x": x})
+
+
+class TestStandardizedResiduals:
+    def test_returns_one_per_row(self, clean_data):
+        result = clean_data.select(
+            standardized_residuals("y", "x").alias("r")
+        ).item()
+        assert result["n_observations"] == 100
+        assert len(result["residuals"]) == 100
+
+    def test_finite_on_well_conditioned_data(self, clean_data):
+        result = clean_data.select(
+            standardized_residuals("y", "x").alias("r")
+        ).item()
+        assert all(np.isfinite(r) for r in result["residuals"])
+
+
+class TestStudentizedResiduals:
+    def test_returns_one_per_row(self, clean_data):
+        result = clean_data.select(
+            studentized_residuals("y", "x").alias("r")
+        ).item()
+        assert result["n_observations"] == 100
+        assert len(result["residuals"]) == 100
+
+    def test_studentized_larger_than_standardized_in_magnitude(self, clean_data):
+        """Studentized residuals divide by sqrt(1 - h_ii) so they're >= standardized."""
+        s = clean_data.select(standardized_residuals("y", "x").alias("s")).item()
+        t = clean_data.select(studentized_residuals("y", "x").alias("t")).item()
+        for std, stu in zip(s["residuals"], t["residuals"]):
+            if np.isfinite(std) and np.isfinite(stu):
+                assert abs(stu) >= abs(std) - 1e-9
+
+
+class TestExternallyStudentizedResiduals:
+    def test_returns_one_per_row(self, clean_data):
+        result = clean_data.select(
+            externally_studentized_residuals("y", "x").alias("r")
+        ).item()
+        assert result["n_observations"] == 100
+        assert len(result["residuals"]) == 100
+
+    def test_outliers_have_large_external_residuals(self, outlier_data):
+        """Planted outliers should produce |t_i| > 3 (rough guideline)."""
+        result = outlier_data.select(
+            externally_studentized_residuals("y", "x").alias("r")
+        ).item()
+        for idx in (3, 17, 42):
+            assert abs(result["residuals"][idx]) > 3.0, (
+                f"outlier at {idx} has externally studentized resid "
+                f"{result['residuals'][idx]:.2f}"
+            )
+
+
+class TestResidualOutliers:
+    def test_no_outliers_on_clean_data(self, clean_data):
+        result = clean_data.select(
+            residual_outliers("y", "x", threshold=3.0).alias("o")
+        ).item()
+        # Should detect very few outliers with threshold 3
+        assert result["n_outliers"] < 5
+        assert result["n_observations"] == 100
+        assert len(result["is_outlier"]) == 100
+
+    def test_flags_planted_outliers(self, outlier_data):
+        result = outlier_data.select(
+            residual_outliers("y", "x", threshold=2.0).alias("o")
+        ).item()
+        # Planted indices should all be flagged
+        for idx in (3, 17, 42):
+            assert result["is_outlier"][idx], f"missed outlier at {idx}"
+        # Total flagged count is at least 3
+        assert result["n_outliers"] >= 3
+
+    def test_default_threshold_is_two(self, outlier_data):
+        """Default threshold = 2.0 — verify by comparing explicit vs implicit."""
+        explicit = outlier_data.select(
+            residual_outliers("y", "x", threshold=2.0).alias("o")
+        ).item()
+        default = outlier_data.select(
+            residual_outliers("y", "x").alias("o")
+        ).item()
+        assert explicit["n_outliers"] == default["n_outliers"]


### PR DESCRIPTION
Partial close for #27 — batch 1 of 4.

## Implemented

Four OLS residual diagnostics from `anofox_regression::diagnostics::residuals`, each as a Polars expression:

| Diagnostic | Expression | Formula |
|---|---|---|
| Standardized residuals | \`ps.standardized_residuals(\"y\", \"x1\", ...)\` | r_i / sqrt(MSE) |
| Studentized residuals | \`ps.studentized_residuals(\"y\", \"x1\", ...)\` | r_i / sqrt(MSE · (1 - h_ii)) |
| Externally studentized | \`ps.externally_studentized_residuals(\"y\", \"x1\", ...)\` | leave-one-out, follows t(n-p-1) |
| Outlier mask | \`ps.residual_outliers(\"y\", \"x1\", ..., threshold=2.0)\` | bool[abs(studentized) > threshold] |

All four follow the rlib split pattern (public `*_fit` + `pl_*` shim) from #13 and #26.

## Implementation notes

A shared `fit_ols_for_residual_diag` helper fits OLS once per call and returns `(residuals, leverage, mse, n_params, n_rows)` — used by all four diagnostics so we don't re-fit per output.

Output shape:
- Three residual diagnostics: `struct{residuals: List<Float64>, n_observations: UInt32}`
- Outlier mask: `struct{is_outlier: List<Boolean>, n_outliers: UInt32, n_observations: UInt32}`

## Tests

- **Python** — `tests/test_residual_diagnostics.py`, 9 new pytests:
  - Each diagnostic returns one value per row.
  - Standardized values are finite on clean data.
  - Studentized magnitudes ≥ standardized (the 1/sqrt(1-h) factor).
  - Externally studentized residuals at planted outlier indices have |t| > 3.
  - `residual_outliers` flags all planted indices with default threshold.
- **Rust** — `tests/rust_api.rs`: smoke tests in `diagnostic_fits` for all four `*_fit` entry points.

Full Python suite: 433/433 pass (424 prior + 9 new). Rust integration: 12/12 pass.

## Remaining work on #27

- **Batch 2** — GLM residual battery: pearson_residuals, deviance_residuals, working_residuals, response_residuals, standardized_pearson_residuals, standardized_deviance_residuals (6 fns × all GLM families).
- **Batch 3** — Influence/leverage extensions: dffits, influential_dffits, influential_cooks, high_leverage_points, compute_leverage_with_aliased.
- **Batch 4** — Multicollinearity + dispersion: generalized_vif, high_vif_predictors, classify_condition_number, variance_decomposition_proportions, pearson_chi_squared, estimate_dispersion_*.

## Test plan

- [x] `cargo build --no-default-features` clean
- [x] `cargo test --no-default-features` — 12/12 pass
- [x] `cargo build` clean
- [x] `pytest` — 433/433 pass
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)