### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-statistics"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Simon Müller <sm@data-zoo.de>"]
 description = "Statistical testing and regression for Polars DataFrames"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-statistics"
-version = "0.4.0"
+version = "0.5.0"
 description = "Statistical tests, regression, and machine learning for Polars - t-tests, ANOVA, chi-square, correlation, OLS, GLM, quantile regression, and more"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/polars_statistics/__init__.py
+++ b/python/polars_statistics/__init__.py
@@ -230,7 +230,7 @@ from polars_statistics.exprs import (
     lm_dynamic_predict,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.5.0"
 
 # Library path for plugin registration
 LIB = Path(__file__).parent


### PR DESCRIPTION
Prep for the v0.5.0 GitHub release. publish.yml fires on \`release: published\` and builds wheels using whatever versions are at the tagged commit, so the bumps need to land before the tag.

- \`Cargo.toml\`: 0.4.0 → 0.5.0
- \`pyproject.toml\`: 0.4.0 → 0.5.0
- \`python/polars_statistics/__init__.py\`: 0.3.0 → 0.5.0 (was lagging two minor versions)

Documentation-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)